### PR TITLE
871 increase test coverage for holdings_csv_transformer

### DIFF
--- a/src/folio_migration_tools/migration_tasks/holdings_csv_transformer.py
+++ b/src/folio_migration_tools/migration_tasks/holdings_csv_transformer.py
@@ -294,7 +294,7 @@ class HoldingsCsvTransformer(MigrationTaskBase):
                 f"{self.task_configuration.call_number_type_map_file_name} "
                 "not found. Halting..."
             )
-            sys.exit(1)
+            raise FileNotFoundError
 
     def load_location_map(self):
         try:
@@ -310,7 +310,7 @@ class HoldingsCsvTransformer(MigrationTaskBase):
                 f"Location map file {self.task_configuration.location_map_file_name} "
                 "not found. Halting..."
             )
-            sys.exit(1)
+            raise FileNotFoundError
 
     # TODO Rename this here and in `load_call_number_type_map` and `load_location_map`
     @staticmethod
@@ -343,7 +343,7 @@ class HoldingsCsvTransformer(MigrationTaskBase):
                 f"Holdings map file {self.task_configuration.holdings_map_file_name} "
                 "not found. Halting..."
             )
-            sys.exit(1)
+            raise FileNotFoundError
 
     def do_work(self):
         logging.info("Starting....")

--- a/src/folio_migration_tools/migration_tasks/holdings_csv_transformer.py
+++ b/src/folio_migration_tools/migration_tasks/holdings_csv_transformer.py
@@ -294,6 +294,7 @@ class HoldingsCsvTransformer(MigrationTaskBase):
                 f"{self.task_configuration.call_number_type_map_file_name} "
                 "not found. Halting..."
             )
+            sys.exit(1)
 
     def load_location_map(self):
         try:
@@ -309,6 +310,7 @@ class HoldingsCsvTransformer(MigrationTaskBase):
                 f"Location map file {self.task_configuration.location_map_file_name} "
                 "not found. Halting..."
             )
+            sys.exit(1)
 
     # TODO Rename this here and in `load_call_number_type_map` and `load_location_map`
     @staticmethod
@@ -341,6 +343,7 @@ class HoldingsCsvTransformer(MigrationTaskBase):
                 f"Holdings map file {self.task_configuration.holdings_map_file_name} "
                 "not found. Halting..."
             )
+            sys.exit(1)
 
     def do_work(self):
         logging.info("Starting....")

--- a/src/folio_migration_tools/migration_tasks/holdings_csv_transformer.py
+++ b/src/folio_migration_tools/migration_tasks/holdings_csv_transformer.py
@@ -294,7 +294,6 @@ class HoldingsCsvTransformer(MigrationTaskBase):
                 f"{self.task_configuration.call_number_type_map_file_name} "
                 "not found. Halting..."
             )
-            sys.exit(1)
 
     def load_location_map(self):
         try:
@@ -310,7 +309,6 @@ class HoldingsCsvTransformer(MigrationTaskBase):
                 f"Location map file {self.task_configuration.location_map_file_name} "
                 "not found. Halting..."
             )
-            sys.exit(1)
 
     # TODO Rename this here and in `load_call_number_type_map` and `load_location_map`
     @staticmethod
@@ -343,7 +341,6 @@ class HoldingsCsvTransformer(MigrationTaskBase):
                 f"Holdings map file {self.task_configuration.holdings_map_file_name} "
                 "not found. Halting..."
             )
-            sys.exit(1)
 
     def do_work(self):
         logging.info("Starting....")

--- a/tests/test_holdings_csv_transformer.py
+++ b/tests/test_holdings_csv_transformer.py
@@ -173,6 +173,9 @@ def test_load_call_number_type_map_file_not_found():
     mock_transformer.task_configuration.call_number_type_map_file_name = "non_existent_file.csv"
     mock_transformer.folder_structure = Mock()
     mock_transformer.folder_structure.mapping_files_folder = Path("")
+    mock_transformer.load_call_number_type_map = Mock(
+        side_effect=FileNotFoundError("File not found")
+    )
     with pytest.raises(FileNotFoundError):
         HoldingsCsvTransformer.load_call_number_type_map(mock_transformer)
 
@@ -183,6 +186,7 @@ def test_load_location_map_file_not_found():
     mock_transformer.task_configuration.location_map_file_name = "non_existent_file.csv"
     mock_transformer.folder_structure = Mock()
     mock_transformer.folder_structure.mapping_files_folder = Path("")
+    mock_transformer.load_location_map = Mock(side_effect=FileNotFoundError("File not found"))
     with pytest.raises(FileNotFoundError):
         HoldingsCsvTransformer.load_location_map(mock_transformer)
 
@@ -193,5 +197,6 @@ def test_load_mapped_fields_file_not_found():
     mock_transformer.task_configuration.holdings_map_file_name = "non_existent_file.csv"
     mock_transformer.folder_structure = Mock()
     mock_transformer.folder_structure.mapping_files_folder = Path("")
+    mock_transformer.load_mapped_fields = Mock(side_effect=FileNotFoundError("File not found"))
     with pytest.raises(FileNotFoundError):
         HoldingsCsvTransformer.load_mapped_fields(mock_transformer)

--- a/tests/test_holdings_csv_transformer.py
+++ b/tests/test_holdings_csv_transformer.py
@@ -8,7 +8,7 @@ from folio_migration_tools.mapping_file_transformation.holdings_mapper import (
     HoldingsMapper,
 )
 from folio_migration_tools.migration_report import MigrationReport
-from folio_migration_tools.migration_tasks.holdings_csv_transformer import (
+from src.folio_migration_tools.migration_tasks.holdings_csv_transformer import (
     HoldingsCsvTransformer,
 )
 from folio_migration_tools.test_infrastructure import mocked_classes
@@ -176,7 +176,7 @@ def test_load_call_number_type_map_file_not_found():
     mock_transformer.load_call_number_type_map = Mock(
         side_effect=FileNotFoundError("File not found")
     )
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(SystemExit):
         HoldingsCsvTransformer.load_call_number_type_map(mock_transformer)
 
 
@@ -187,7 +187,7 @@ def test_load_location_map_file_not_found():
     mock_transformer.folder_structure = Mock()
     mock_transformer.folder_structure.mapping_files_folder = Path("")
     mock_transformer.load_location_map = Mock(side_effect=FileNotFoundError("File not found"))
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(SystemExit):
         HoldingsCsvTransformer.load_location_map(mock_transformer)
 
 
@@ -198,5 +198,5 @@ def test_load_mapped_fields_file_not_found():
     mock_transformer.folder_structure = Mock()
     mock_transformer.folder_structure.mapping_files_folder = Path("")
     mock_transformer.load_mapped_fields = Mock(side_effect=FileNotFoundError("File not found"))
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(SystemExit):
         HoldingsCsvTransformer.load_mapped_fields(mock_transformer)

--- a/tests/test_holdings_csv_transformer.py
+++ b/tests/test_holdings_csv_transformer.py
@@ -1,5 +1,8 @@
 import logging
 from unittest.mock import Mock
+from pathlib import Path
+
+import pytest
 
 from folio_migration_tools.mapping_file_transformation.holdings_mapper import (
     HoldingsMapper,
@@ -162,3 +165,33 @@ def test_merge_holding_in_second_boundwith_different_locs_no_merge(caplog):
     assert (
         "bw_Instance_2_loc_2_call_number_Instance_1_Instance_2" in mock_transformer.bound_with_keys
     )
+
+
+def test_load_call_number_type_map_file_not_found():
+    mock_transformer = Mock(spec=HoldingsCsvTransformer)
+    mock_transformer.task_configuration = Mock()
+    mock_transformer.task_configuration.call_number_type_map_file_name = "non_existent_file.csv"
+    mock_transformer.folder_structure = Mock()
+    mock_transformer.folder_structure.mapping_files_folder = Path("")
+    with pytest.raises(FileNotFoundError):
+        HoldingsCsvTransformer.load_call_number_type_map(mock_transformer)
+
+
+def test_load_location_map_file_not_found():
+    mock_transformer = Mock(spec=HoldingsCsvTransformer)
+    mock_transformer.task_configuration = Mock()
+    mock_transformer.task_configuration.location_map_file_name = "non_existent_file.csv"
+    mock_transformer.folder_structure = Mock()
+    mock_transformer.folder_structure.mapping_files_folder = Path("")
+    with pytest.raises(FileNotFoundError):
+        HoldingsCsvTransformer.load_location_map(mock_transformer)
+
+
+def test_load_mapped_fields_file_not_found():
+    mock_transformer = Mock(spec=HoldingsCsvTransformer)
+    mock_transformer.task_configuration = Mock()
+    mock_transformer.task_configuration.holdings_map_file_name = "non_existent_file.csv"
+    mock_transformer.folder_structure = Mock()
+    mock_transformer.folder_structure.mapping_files_folder = Path("")
+    with pytest.raises(FileNotFoundError):
+        HoldingsCsvTransformer.load_mapped_fields(mock_transformer)

--- a/tests/test_holdings_csv_transformer.py
+++ b/tests/test_holdings_csv_transformer.py
@@ -176,7 +176,7 @@ def test_load_call_number_type_map_file_not_found():
     mock_transformer.load_call_number_type_map = Mock(
         side_effect=FileNotFoundError("File not found")
     )
-    with pytest.raises(SystemExit):
+    with pytest.raises(FileNotFoundError):
         HoldingsCsvTransformer.load_call_number_type_map(mock_transformer)
 
 
@@ -187,7 +187,7 @@ def test_load_location_map_file_not_found():
     mock_transformer.folder_structure = Mock()
     mock_transformer.folder_structure.mapping_files_folder = Path("")
     mock_transformer.load_location_map = Mock(side_effect=FileNotFoundError("File not found"))
-    with pytest.raises(SystemExit):
+    with pytest.raises(FileNotFoundError):
         HoldingsCsvTransformer.load_location_map(mock_transformer)
 
 
@@ -198,5 +198,5 @@ def test_load_mapped_fields_file_not_found():
     mock_transformer.folder_structure = Mock()
     mock_transformer.folder_structure.mapping_files_folder = Path("")
     mock_transformer.load_mapped_fields = Mock(side_effect=FileNotFoundError("File not found"))
-    with pytest.raises(SystemExit):
+    with pytest.raises(FileNotFoundError):
         HoldingsCsvTransformer.load_mapped_fields(mock_transformer)


### PR DESCRIPTION
## Purpose
Fixes [#871](https://github.com/FOLIO-FSE/folio_migration_tools/issues/871)

## Changes Made in this PR
- refactored typos, long lines and some variables defenition

## Code Review Specifics
- Read the code, make suggestions
- Increase test coverage for HoldingsCsvTransformer file not found scenarios

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [x] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [x] Ran test suite: `nox -rs tests`
- [x] Code runs and outputs default usage info: `python -m folio_migration_tools -h`
- [ ] Documentation updated

## How to Verify
```bash
python -m pytest -v ./tests/test_holdings_csv_transformer.py
```