### PR TITLE
Feature/support lists in legacy fallback field mapping option

### DIFF
--- a/docs/source/mapping_file_based_mapping.md
+++ b/docs/source/mapping_file_based_mapping.md
@@ -60,10 +60,14 @@ There might be exceptions to this in some areas, but generally, this is the how 
     - *legacy_field*
     - *fallback_legacy_field* (string or ordered array, first non-empty)
     - *fallback_value*
-4. If a source value was resolved from *legacy_field*, *fallback_legacy_field*, or *fallback_value*, rules are applied once to that resolved value.
-5. If there is an entry for rules.regexGsub, it is applied first.
-6. If there is an entry for rules.replaceValues, it is applied next.
-7. If there is an entry for rules.regexGetFirstMatchOrEmpty, it is applied last.
+4. By default, if a source value was resolved from *legacy_field* or *fallback_legacy_field*, rules are applied once to that resolved value.
+5. If the resolved value came from *fallback_value*, rules are not applied (literal fallback behavior, same as *value*).
+
+#### Rule execution order
+The following order applies only when rules are applied (that is, when the resolved source is *legacy_field* or *fallback_legacy_field*):
+1. If there is an entry for rules.regexGsub, it is applied first.
+2. If there is an entry for rules.replaceValues, it is applied next.
+3. If there is an entry for rules.regexGetFirstMatchOrEmpty, it is applied last.
 
 *If there are multiple mapping entries for the same FOLIO field, the results from the above process will get concatenated with a space between them, in the order that they appear in the mapping file.*
 
@@ -224,14 +228,34 @@ Ordered fallback fields:
 ### The fallback_value property
 The fallback_value is used as a last resort, so if no other mappings have returned a value, this value will be set.
 
-If rules are defined in the mapping entry, they are applied once to the resolved fallback_value in the same way as for legacy_field/fallback_legacy_field values.
+The fallback_value is treated as a literal fallback (same behavior as *value*), so rules are not applied to it.
 
 ### The rules mapping entry
 This is a placeHolder for more advanced mappings.
 
-Rules are applied once after a source value has been resolved (*legacy_field*, *fallback_legacy_field*, or *fallback_value*).
+Rules are applied once after a source value has been resolved from *legacy_field* or *fallback_legacy_field*.
 
 If *value* is explicitly set in the mapping entry, that literal value is returned directly and rules are not applied.
+
+If *fallback_value* is set, it is only used after *legacy_field* and *fallback_legacy_field* resolution returns no value. When used, *fallback_value* is treated as a literal and rules are not applied.
+
+Optional: you can control this behavior with *rules_apply_scope* in a mapping entry:
+- *resolved_non_literal* (default): apply rules for *legacy_field* and *fallback_legacy_field* sources
+- *legacy_only*: apply rules only when the resolved source is *legacy_field*
+- *none*: do not apply rules for that mapping entry
+
+Example:
+```
+{
+    "folio_field": "email",
+    "legacy_field": "PRIMARY EMAIL",
+    "fallback_legacy_field": "SECONDARY EMAIL",
+    "rules_apply_scope": "legacy_only",
+    "rules": {
+        "regexGetFirstMatchOrEmpty": "(.*)@.*"
+    }
+}
+```
 
 ### rules.regexGetFirstMatchOrEmpty
 This propety should contain a regular expression with a capturing group. The resulting string will be the first capturing group. Imagine the following mapping:

--- a/docs/source/mapping_file_based_mapping.md
+++ b/docs/source/mapping_file_based_mapping.md
@@ -59,7 +59,7 @@ There might be exceptions to this in some areas, but generally, this is the how 
 3. Then, the *legacy field* value gets extracted from the source record.
 4. If there is an entry for rules.replaceValues, the extracted value is run through this process
 5. If there is an entry for rules.regexGetFirstMatchOrEmpty, the extracted value is run through this process as well and then return the value
-6. If the above steps does not result in a value, and if there is a fallback field in the legacy data, mapped by the *fallback_legacy_field*, this field will be returned
+6. If the above steps does not result in a value, and if there is a fallback field in the legacy data, mapped by the *fallback_legacy_field*, this field will be returned. If *fallback_legacy_field* is an array, each field is evaluated in order and the first non-empty value is returned.
 7. If none of the above have resulted in a value, and there is an entry for *fallback_value* in the mapping entry, this value will be returned
 
 *If there are multiple mapping entries for the same FOLIO field, the results from the above process will get concatenated with a space between them, in the order that they appear in the mapping file.*
@@ -188,7 +188,35 @@ The value property is a way to add the same value to all records.
 The description field is used for your own notes.
 
 ### The fallback_legacy_field property
-The fallback_legacy_field is used as a falback, so when the legacy_field and the fallback_legacy_field is mapped and has a value, this value will be used.
+The fallback_legacy_field is used as a fallback, so when the legacy_field does not produce a value, fallback_legacy_field is checked.
+
+This property accepts either:
+- A string (backward-compatible behavior)
+- An array of strings for ordered fallback resolution
+
+Examples:
+
+Single fallback field:
+```
+{
+    "folio_field": "email",
+    "legacy_field": "PRIMARY EMAIL",
+    "fallback_legacy_field": "SECONDARY EMAIL"
+}
+```
+
+Ordered fallback fields:
+```
+{
+    "folio_field": "email",
+    "legacy_field": "PRIMARY EMAIL",
+    "fallback_legacy_field": [
+        "SECONDARY EMAIL",
+        "WORK EMAIL",
+        "RECORD #(PATRON)"
+    ]
+}
+```
 
 ### The fallback_value property
 The fallback_value is used as a last resort, so if no other mappings have returned a value, this value will be set.

--- a/docs/source/mapping_file_based_mapping.md
+++ b/docs/source/mapping_file_based_mapping.md
@@ -55,12 +55,15 @@ folio_field and legacy_field are mandatory. All other fields are optional.
 ### The priority of the mappings in the mapping entry:
 There might be exceptions to this in some areas, but generally, this is the how the mapping works:
 1. If there are reference data mappings or special cases for particular fields, then this has precedence
-2. Values added to the *value* field are returned immediately without any further manipulation
-3. Then, the *legacy field* value gets extracted from the source record.
-4. If there is an entry for rules.replaceValues, the extracted value is run through this process
-5. If there is an entry for rules.regexGetFirstMatchOrEmpty, the extracted value is run through this process as well and then return the value
-6. If the above steps does not result in a value, and if there is a fallback field in the legacy data, mapped by the *fallback_legacy_field*, this field will be returned. If *fallback_legacy_field* is an array, each field is evaluated in order and the first non-empty value is returned.
-7. If none of the above have resulted in a value, and there is an entry for *fallback_value* in the mapping entry, this value will be returned
+2. Values added to the *value* field are returned immediately without any further manipulation (rules are not applied)
+3. If *value* is not set, a source value is resolved in this order:
+    - *legacy_field*
+    - *fallback_legacy_field* (string or ordered array, first non-empty)
+    - *fallback_value*
+4. If a source value was resolved from *legacy_field*, *fallback_legacy_field*, or *fallback_value*, rules are applied once to that resolved value.
+5. If there is an entry for rules.regexGsub, it is applied first.
+6. If there is an entry for rules.replaceValues, it is applied next.
+7. If there is an entry for rules.regexGetFirstMatchOrEmpty, it is applied last.
 
 *If there are multiple mapping entries for the same FOLIO field, the results from the above process will get concatenated with a space between them, in the order that they appear in the mapping file.*
 
@@ -221,8 +224,14 @@ Ordered fallback fields:
 ### The fallback_value property
 The fallback_value is used as a last resort, so if no other mappings have returned a value, this value will be set.
 
+If rules are defined in the mapping entry, they are applied once to the resolved fallback_value in the same way as for legacy_field/fallback_legacy_field values.
+
 ### The rules mapping entry
-This is a placeHolder for more advanced mappings. 
+This is a placeHolder for more advanced mappings.
+
+Rules are applied once after a source value has been resolved (*legacy_field*, *fallback_legacy_field*, or *fallback_value*).
+
+If *value* is explicitly set in the mapping entry, that literal value is returned directly and rules are not applied.
 
 ### rules.regexGetFirstMatchOrEmpty
 This propety should contain a regular expression with a capturing group. The resulting string will be the first capturing group. Imagine the following mapping:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "folio_migration_tools"
-version = "1.12.2"
+version = "1.12.3"
 description =  "A tool allowing you to migrate data from legacy ILS:s (Library systems) into FOLIO LSP"
 authors = [
 	{name = "Theodor Tolstoy", email = "github.teddes@tolstoy.se"},

--- a/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
+++ b/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
@@ -408,6 +408,11 @@ class MappingFileMapperBase(MapperBase):
             migration_report,
         )
 
+        if not MappingFileMapperBase.should_apply_rules_for_source(
+            source_field, mapping_file_entry
+        ):
+            return value
+
         return MappingFileMapperBase.apply_rules_to_resolved_value(
             value,
             source_field,
@@ -415,6 +420,20 @@ class MappingFileMapperBase(MapperBase):
             migration_report,
             multi_field_delimiter,
         )
+
+    @staticmethod
+    def should_apply_rules_for_source(source_field: str, mapping_file_entry: dict) -> bool:
+        # fallback_value is a literal fallback and should bypass rules, like value.
+        if source_field == "fallback_value":
+            return False
+
+        rules_apply_scope = mapping_file_entry.get("rules_apply_scope", "resolved_non_literal")
+        if rules_apply_scope == "none":
+            return False
+        if rules_apply_scope == "legacy_only":
+            return source_field == mapping_file_entry.get("legacy_field", "")
+
+        return True
 
     @staticmethod
     def resolve_mapped_legacy_value(

--- a/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
+++ b/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
@@ -402,19 +402,77 @@ class MappingFileMapperBase(MapperBase):
             )
             return value_mapped_value
 
-        # Value mapped from the Legacy field(s)
-        value = legacy_object.get(mapping_file_entry["legacy_field"], "")
+        value, source_field = MappingFileMapperBase.resolve_mapped_legacy_value(
+            legacy_object,
+            mapping_file_entry,
+            migration_report,
+        )
 
-        if value and mapping_file_entry.get("rules", {}).get("regexGsub", ""):
+        return MappingFileMapperBase.apply_rules_to_resolved_value(
+            value,
+            source_field,
+            mapping_file_entry,
+            migration_report,
+            multi_field_delimiter,
+        )
+
+    @staticmethod
+    def resolve_mapped_legacy_value(
+        legacy_object: dict, mapping_file_entry: dict, migration_report
+    ):
+        primary_field = mapping_file_entry["legacy_field"]
+        value = legacy_object.get(primary_field, "")
+        if value:
+            return value, primary_field
+
+        fallback_field, fallback_value = MappingFileMapperBase.get_fallback_legacy_value(
+            legacy_object,
+            mapping_file_entry.get("fallback_legacy_field", ""),
+        )
+        if fallback_field and fallback_value not in ["", None]:
+            migration_report.add(
+                "FieldMappingDetails",
+                (
+                    f"Added fallback value from {fallback_field} "
+                    f"instead of {mapping_file_entry['legacy_field']}"
+                ),
+            )
+            return fallback_value, fallback_field
+
+        fallback_value_literal = mapping_file_entry.get("fallback_value", "")
+        if fallback_value_literal:
+            migration_report.add(
+                "FieldMappingDetails",
+                (
+                    f"Added fallback value {fallback_value_literal} "
+                    f"instead of empty {mapping_file_entry['legacy_field']}"
+                ),
+            )
+            return fallback_value_literal, "fallback_value"
+
+        return value, primary_field
+
+    @staticmethod
+    def apply_rules_to_resolved_value(
+        value,
+        source_field,
+        mapping_file_entry: dict,
+        migration_report: MigrationReport,
+        multi_field_delimiter="",
+    ):
+        if not value:
+            return value
+
+        if mapping_file_entry.get("rules", {}).get("regexGsub", ""):
             gsub_rule = mapping_file_entry.get("rules", {}).get("regexGsub", "")
-
             if not isinstance(gsub_rule, dict):
                 raise ValueError("regexGsub must be a dictionary with 'pattern' and 'replacement'")
 
             pattern = gsub_rule.get("pattern", "")
             replacement = gsub_rule.get("replacement", "")
             value = re.sub(pattern, replacement, value)
-        if value and mapping_file_entry.get("rules", {}).get("replaceValues", {}):
+
+        if mapping_file_entry.get("rules", {}).get("replaceValues", {}):
             if multi_field_delimiter and multi_field_delimiter in value:
                 replaced_split_values = [
                     mapping_file_entry["rules"]["replaceValues"].get(sv, "")
@@ -427,40 +485,16 @@ class MappingFileMapperBase(MapperBase):
             if replaced_val or isinstance(replaced_val, bool):
                 migration_report.add(
                     "FieldMappingDetails",
-                    (
-                        f"Replaced {value} in {mapping_file_entry['legacy_field']} "
-                        f"with {replaced_val}"
-                    ),
+                    f"Replaced {value} in {source_field} with {replaced_val}",
                 )
                 value = replaced_val
-        if value and mapping_file_entry.get("rules", {}).get("regexGetFirstMatchOrEmpty", ""):
+
+        if mapping_file_entry.get("rules", {}).get("regexGetFirstMatchOrEmpty", ""):
             my_pattern = (
                 f"{mapping_file_entry.get('rules', {}).get('regexGetFirstMatchOrEmpty')}|$"
             )
             value = re.findall(my_pattern, value)[0]
-        if not value and mapping_file_entry.get("fallback_legacy_field", ""):
-            fallback_field, fallback_value = MappingFileMapperBase.get_fallback_legacy_value(
-                legacy_object,
-                mapping_file_entry.get("fallback_legacy_field", ""),
-            )
-            if fallback_field and fallback_value not in ["", None]:
-                migration_report.add(
-                    "FieldMappingDetails",
-                    (
-                        f"Added fallback value from {fallback_field} "
-                        f"instead of {mapping_file_entry['legacy_field']}"
-                    ),
-                )
-                value = fallback_value
-        if not value and mapping_file_entry.get("fallback_value", ""):
-            migration_report.add(
-                "FieldMappingDetails",
-                (
-                    f"Added fallback value {mapping_file_entry['fallback_value']} "
-                    f"instead of empty {mapping_file_entry['legacy_field']}"
-                ),
-            )
-            value = mapping_file_entry.get("fallback_value", "")
+
         return value
 
     @staticmethod

--- a/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
+++ b/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
@@ -439,16 +439,19 @@ class MappingFileMapperBase(MapperBase):
             )
             value = re.findall(my_pattern, value)[0]
         if not value and mapping_file_entry.get("fallback_legacy_field", ""):
-            migration_report.add(
-                "FieldMappingDetails",
-                (
-                    f"Added fallback value from {mapping_file_entry['fallback_legacy_field']} "
-                    f"instead of {mapping_file_entry['legacy_field']}"
-                ),
+            fallback_field, fallback_value = MappingFileMapperBase.get_fallback_legacy_value(
+                legacy_object,
+                mapping_file_entry.get("fallback_legacy_field", ""),
             )
-            value = legacy_object.get(
-                mapping_file_entry.get("fallback_legacy_field", ""), ""
-            ).strip()
+            if fallback_field and fallback_value not in ["", None]:
+                migration_report.add(
+                    "FieldMappingDetails",
+                    (
+                        f"Added fallback value from {fallback_field} "
+                        f"instead of {mapping_file_entry['legacy_field']}"
+                    ),
+                )
+                value = fallback_value
         if not value and mapping_file_entry.get("fallback_value", ""):
             migration_report.add(
                 "FieldMappingDetails",
@@ -459,6 +462,33 @@ class MappingFileMapperBase(MapperBase):
             )
             value = mapping_file_entry.get("fallback_value", "")
         return value
+
+    @staticmethod
+    def normalize_fallback_legacy_fields(fallback_legacy_field):
+        if isinstance(fallback_legacy_field, str):
+            return (
+                [fallback_legacy_field] if fallback_legacy_field.strip() not in empty_vals else []
+            )
+        if isinstance(fallback_legacy_field, list):
+            return [
+                field
+                for field in fallback_legacy_field
+                if isinstance(field, str) and field.strip() not in empty_vals
+            ]
+        return []
+
+    @staticmethod
+    def get_fallback_legacy_value(legacy_object: dict, fallback_legacy_field):
+        fallback_fields = MappingFileMapperBase.normalize_fallback_legacy_fields(
+            fallback_legacy_field
+        )
+        for fallback_field in fallback_fields:
+            fallback_value = legacy_object.get(fallback_field, "")
+            if isinstance(fallback_value, str):
+                fallback_value = fallback_value.strip()
+            if fallback_value not in ["", None]:
+                return fallback_field, fallback_value
+        return "", ""
 
     @staticmethod
     def get_legacy_vals(legacy_item, legacy_item_keys):
@@ -1232,6 +1262,8 @@ def in_deep(dictionary, keys):
 
 
 def is_set_or_bool_or_numeric(any_value):
+    if isinstance(any_value, list):
+        return any(is_set_or_bool_or_numeric(value) for value in any_value)
     return (isinstance(any_value, str) and (any_value.strip() not in empty_vals)) or isinstance(
         any_value, (int, float, complex)
     )

--- a/src/folio_migration_tools/migration_tasks/items_transformer.py
+++ b/src/folio_migration_tools/migration_tasks/items_transformer.py
@@ -40,7 +40,7 @@ from folio_migration_tools.task_configuration import AbstractTaskConfiguration
 
 logger = logging.getLogger(__name__)
 
-csv.field_size_limit(int(ctypes.c_ulong(-1).value // 2))
+csv.field_size_limit((ctypes.c_ulong(-1).value // 2))
 
 
 class ItemsTransformer(MigrationTaskBase):
@@ -183,7 +183,7 @@ class ItemsTransformer(MigrationTaskBase):
                     "formatted boundwith relationship file to be provided."
                 ),
             ),
-        ] = "voyager"
+        ] = IlsFlavour.voyager
         boundwith_relationship_file_path: Annotated[
             str,
             Field(
@@ -231,7 +231,7 @@ class ItemsTransformer(MigrationTaskBase):
         csv.register_dialect("tsv", delimiter="\t")
         super().__init__(library_config, task_config, folio_client, use_logging)
         self.task_config = task_config
-        self.task_configuration = self.task_config
+        self.task_configuration: ItemsTransformer.TaskConfiguration = self.task_config
         self.check_source_files(
             self.folder_structure.legacy_records_folder, self.task_config.files
         )

--- a/tests/test_mapping_file_mapper_base.py
+++ b/tests/test_mapping_file_mapper_base.py
@@ -4975,7 +4975,57 @@ def test_get_legacy_value_fallback_field_then_rules_applied_once():
     assert res == "Graduate"
 
 
-def test_get_legacy_value_fallback_value_then_rules_applied_once():
+def test_get_legacy_value_rules_apply_scope_legacy_only_skips_fallback_field_rules():
+    legacy_object = {"title": "", "alternative_title": "0"}
+    mapping_file_entry = {
+        "folio_field": "title",
+        "legacy_field": "title",
+        "value": "",
+        "description": "",
+        "fallback_legacy_field": "alternative_title",
+        "rules_apply_scope": "legacy_only",
+        "rules": {"replaceValues": {"0": "Graduate", "a": "Alumni"}},
+    }
+    res = MappingFileMapperBase.get_legacy_value(
+        legacy_object, mapping_file_entry, MigrationReport(), ""
+    )
+    assert res == "0"
+
+
+def test_get_legacy_value_rules_apply_scope_legacy_only_applies_primary_rules():
+    legacy_object = {"title": "0", "alternative_title": "a"}
+    mapping_file_entry = {
+        "folio_field": "title",
+        "legacy_field": "title",
+        "value": "",
+        "description": "",
+        "fallback_legacy_field": "alternative_title",
+        "rules_apply_scope": "legacy_only",
+        "rules": {"replaceValues": {"0": "Graduate", "a": "Alumni"}},
+    }
+    res = MappingFileMapperBase.get_legacy_value(
+        legacy_object, mapping_file_entry, MigrationReport(), ""
+    )
+    assert res == "Graduate"
+
+
+def test_get_legacy_value_rules_apply_scope_none_disables_rules():
+    legacy_object = {"title": "0"}
+    mapping_file_entry = {
+        "folio_field": "title",
+        "legacy_field": "title",
+        "value": "",
+        "description": "",
+        "rules_apply_scope": "none",
+        "rules": {"replaceValues": {"0": "Graduate", "a": "Alumni"}},
+    }
+    res = MappingFileMapperBase.get_legacy_value(
+        legacy_object, mapping_file_entry, MigrationReport(), ""
+    )
+    assert res == "0"
+
+
+def test_get_legacy_value_fallback_value_bypasses_rules():
     legacy_object = {"title": "", "alternative_title": ""}
     mapping_file_entry = {
         "folio_field": "title",
@@ -4989,7 +5039,7 @@ def test_get_legacy_value_fallback_value_then_rules_applied_once():
     res = MappingFileMapperBase.get_legacy_value(
         legacy_object, mapping_file_entry, MigrationReport(), ""
     )
-    assert res == "fallback"
+    assert res == "fallback@leifochbilly.se"
 
 
 def test_get_legacy_value_literal_value_still_bypasses_rules():

--- a/tests/test_mapping_file_mapper_base.py
+++ b/tests/test_mapping_file_mapper_base.py
@@ -4959,6 +4959,54 @@ def test_get_legacy_value_fallback_field_list_then_fallback_value():
     assert res == "default@leifochbilly.se"
 
 
+def test_get_legacy_value_fallback_field_then_rules_applied_once():
+    legacy_object = {"title": "", "alternative_title": "0"}
+    mapping_file_entry = {
+        "folio_field": "title",
+        "legacy_field": "title",
+        "value": "",
+        "description": "",
+        "fallback_legacy_field": "alternative_title",
+        "rules": {"replaceValues": {"0": "Graduate", "a": "Alumni"}},
+    }
+    res = MappingFileMapperBase.get_legacy_value(
+        legacy_object, mapping_file_entry, MigrationReport(), ""
+    )
+    assert res == "Graduate"
+
+
+def test_get_legacy_value_fallback_value_then_rules_applied_once():
+    legacy_object = {"title": "", "alternative_title": ""}
+    mapping_file_entry = {
+        "folio_field": "title",
+        "legacy_field": "title",
+        "value": "",
+        "description": "",
+        "fallback_legacy_field": "alternative_title",
+        "fallback_value": "fallback@leifochbilly.se",
+        "rules": {"regexGetFirstMatchOrEmpty": "(.*)@.*"},
+    }
+    res = MappingFileMapperBase.get_legacy_value(
+        legacy_object, mapping_file_entry, MigrationReport(), ""
+    )
+    assert res == "fallback"
+
+
+def test_get_legacy_value_literal_value_still_bypasses_rules():
+    legacy_object = {"title": "0"}
+    mapping_file_entry = {
+        "folio_field": "title",
+        "legacy_field": "title",
+        "value": "Torsten",
+        "description": "",
+        "rules": {"replaceValues": {"Torsten": "Changed"}},
+    }
+    res = MappingFileMapperBase.get_legacy_value(
+        legacy_object, mapping_file_entry, MigrationReport(), ""
+    )
+    assert res == "Torsten"
+
+
 def test_get_legacy_value_fallback_value():
     legacy_object = {"title": "", "alternative_title": ""}
     mapping_file_entry = {

--- a/tests/test_mapping_file_mapper_base.py
+++ b/tests/test_mapping_file_mapper_base.py
@@ -4923,6 +4923,42 @@ def test_get_legacy_value_fallback_field():
     assert res == "billy@leifochbilly.se"
 
 
+def test_get_legacy_value_fallback_field_list_uses_first_non_empty_value():
+    legacy_object = {
+        "title": "",
+        "alternative_title": "",
+        "backup_title": "backup@leifochbilly.se",
+        "third_title": "third@leifochbilly.se",
+    }
+    mapping_file_entry = {
+        "folio_field": "title",
+        "legacy_field": "title",
+        "value": "",
+        "description": "",
+        "fallback_legacy_field": ["alternative_title", "backup_title", "third_title"],
+    }
+    res = MappingFileMapperBase.get_legacy_value(
+        legacy_object, mapping_file_entry, MigrationReport(), ""
+    )
+    assert res == "backup@leifochbilly.se"
+
+
+def test_get_legacy_value_fallback_field_list_then_fallback_value():
+    legacy_object = {"title": "", "alternative_title": "", "backup_title": ""}
+    mapping_file_entry = {
+        "folio_field": "title",
+        "legacy_field": "title",
+        "value": "",
+        "description": "",
+        "fallback_legacy_field": ["alternative_title", "backup_title"],
+        "fallback_value": "default@leifochbilly.se",
+    }
+    res = MappingFileMapperBase.get_legacy_value(
+        legacy_object, mapping_file_entry, MigrationReport(), ""
+    )
+    assert res == "default@leifochbilly.se"
+
+
 def test_get_legacy_value_fallback_value():
     legacy_object = {"title": "", "alternative_title": ""}
     mapping_file_entry = {
@@ -5436,6 +5472,28 @@ def test_get_map_entries_by_folio_prop_name_with_partial_matches():
     result = list(MappingFileMapperBase.get_map_entries_by_folio_prop_name("title", data))
     assert len(result) == 1
     assert result[0]["value"] == "Valid Value"
+
+
+def test_get_map_entries_by_folio_prop_name_with_fallback_legacy_field_list():
+    data = [
+        {
+            "folio_field": "title",
+            "value": "",
+            "legacy_field": "",
+            "fallback_legacy_field": ["alternative_title", "backup_title"],
+            "fallback_value": "",
+        },
+        {
+            "folio_field": "author",
+            "value": "",
+            "legacy_field": "",
+            "fallback_legacy_field": "",
+            "fallback_value": "",
+        },
+    ]
+    result = list(MappingFileMapperBase.get_map_entries_by_folio_prop_name("title", data))
+    assert len(result) == 1
+    assert result[0]["fallback_legacy_field"] == ["alternative_title", "backup_title"]
 
 
 def test_map_array_object_array_string_with_delimiter_and_delimited_enum(

--- a/tests/test_organization_mapper.py
+++ b/tests/test_organization_mapper.py
@@ -169,6 +169,27 @@ def test_use_fallback_legacy_field_if_legacy_field_empty(mapper):
     assert organization["accounts"][0]["name"] == "Abby Books"
 
 
+def test_use_fallback_legacy_field_list_in_order(mapper):
+    data["name"] = "Abby Books"
+    data["code"] = "fallback_from_code"
+    data["account_number"] = "123"
+    data["account_status"] = "Active"
+    data["account_name"] = ""
+
+    account_name_entry = next(
+        entry for entry in organization_map["data"] if entry["folio_field"] == "accounts[0].name"
+    )
+    original_fallback = account_name_entry.get("fallback_legacy_field", "")
+
+    try:
+        account_name_entry["fallback_legacy_field"] = ["missing_field", "code"]
+        organization, idx = mapper.do_map(data, data["code"], FOLIONamespaces.organizations)
+    finally:
+        account_name_entry["fallback_legacy_field"] = original_fallback
+
+    assert organization["accounts"][0]["name"] == "fallback_from_code"
+
+
 def test_single_org_type_refdata_mapping(mapper):
     data["code"] = "ov9"
     organization, idx = mapper.do_map(data, data["code"], FOLIONamespaces.organizations)

--- a/tests/test_user_mapper.py
+++ b/tests/test_user_mapper.py
@@ -342,6 +342,59 @@ def test_basic_fallback(mocked_folio_client):
     assert folio_user["externalSystemId"] == "externalid_2"
 
 
+def test_basic_fallback_list(mocked_folio_client):
+    user_map = {
+        "data": [
+            {
+                "folio_field": "username",
+                "legacy_field": "user_name",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "externalSystemId",
+                "legacy_field": "ext_id",
+                "value": "",
+                "description": "",
+                "fallback_legacy_field": ["ext_id2", "ext_id3"],
+            },
+            {
+                "folio_field": "legacyIdentifier",
+                "legacy_field": "id",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "personal.lastName",
+                "legacy_field": "",
+                "value": "Last name",
+                "description": "",
+            },
+        ]
+    }
+    legacy_user_record = {
+        "ext_id": "",
+        "ext_id2": "",
+        "ext_id3": "externalid_3",
+        "user_name": "user_name_1",
+        "id": "1",
+    }
+    mock_library_conf = mocked_classes.get_mocked_library_config()
+    mock_task_config = Mock(spec=UserTransformer.TaskConfiguration)
+    mock_task_config.remove_id_and_request_preferences = False
+    mock_task_config.remove_request_preferences = False
+    mock_task_config.remove_username = False
+    mock_library_conf.multi_field_delimiter = "<delimiter>"
+    user_mapper = UserMapper(
+        mocked_folio_client, mock_task_config, mock_library_conf, user_map, None, None
+    )
+    folio_user, index_or_id = user_mapper.do_map(legacy_user_record, "001", FOLIONamespaces.users)
+    folio_user = user_mapper.perform_additional_mapping(
+        legacy_user_record, folio_user, index_or_id
+    )
+    assert folio_user["externalSystemId"] == "externalid_3"
+
+
 def test_basic_fallback_value(mocked_folio_client):
     user_map = {
         "data": [


### PR DESCRIPTION
## Purpose
Improve mapping-file fallback and rule-processing behavior for delimited-file transformations while keeping defaults predictable and explicit.

This PR adds support for ordered fallback_legacy_field arrays, refactors get_legacy_value for clearer source-resolution and rule-processing flow, restores fallback_value as a literal final fallback (no rules applied), and introduces a phase-1 rules scope option so teams can control whether rules apply to fallback-derived values.

## Changes Made in this PR
- Added ordered fallback_legacy_field support:
  - fallback_legacy_field now accepts either a string or an ordered array of field names.
  - Resolution uses the first non-empty fallback field in list order.
- Refactored get_legacy_value for clarity:
  - value source resolution and rule application are separated into helper methods.
  - Complexity is reduced while preserving existing value-literal precedence behavior.
- Updated fallback_value behavior:
  - fallback_value is treated as a literal fallback (same as value) and bypasses rules.
  - fallback_value is only used after legacy_field and fallback_legacy_field resolution produce no value.
- Added rules scope configuration (phase 1):
  - New optional mapping-entry key: rules_apply_scope
  - supported values:
    - resolved_non_literal (default): apply rules to legacy_field/fallback_legacy_field sources
    - legacy_only: apply rules only when source is legacy_field
    - none: disable rules for that mapping entry
- Expanded test coverage:
  - Unit tests for ordered fallback list behavior.
  - Unit tests for fallback_value literal bypass.
  - Unit tests for rules_apply_scope (legacy_only and none).
  - Integration-level tests in user and organization mapper suites for fallback list behavior.
- Updated documentation:
  - Clarified source resolution priority and separated rule execution order into its own mini-section.
  - Documented fallback_value precedence and literal behavior.
  - Documented rules_apply_scope options and example usage.

## Code Review Specifics
- Please focus review on fallback precedence and backward compatibility guarantees:
  - string fallback path should remain unchanged
  - list fallback should stop at first non-empty field
  - fallback_value should apply only after all fallback fields fail
- Please verify helper behavior for map-entry inclusion with list values.

## Task Checklist
- [ ] Ran nox -rs safety.
- [x] Ran pre-commit run --all-files
- [x] Tests cover new or modified code.
- [x] Ran test suite: nox -rs tests
- [x] Code runs and outputs default usage info: cd src; poetry run python3 -m folio_migration_tools -h
- [x] Documentation updated

## Warning Checklist
- [ ] New dependencies added
- [ ] Includes breaking changes

## How to Verify
1. Run focused tests:
   - source .env && .venv/bin/python -m pytest -q test_mapping_file_mapper_base.py -k "fallback_field or get_map_entries_by_folio_prop_name"
2. Confirm new tests pass:
   - test_get_legacy_value_fallback_field_list_uses_first_non_empty_value
   - test_get_legacy_value_fallback_field_list_then_fallback_value
   - test_get_map_entries_by_folio_prop_name_with_fallback_legacy_field_list
3. Spot-check unchanged legacy behavior:
   - test_get_legacy_value_fallback_field still passes (string fallback).
4. Review documentation updates in mapping-file syntax and fallback section:
   - mapping_file_based_mapping.md

## Open Questions
## Learn Anything Cool?

