### PR TITLE
Add address type validation and dedupe in UserTransformer

### DIFF
--- a/docs/source/tasks/user_transformer.md
+++ b/docs/source/tasks/user_transformer.md
@@ -139,6 +139,23 @@ Map multiple addresses using array indexing:
 }
 ```
 
+## Address Validation Rules
+
+During cleanup, UserTransformer enforces the following rules for `personal.addresses`:
+
+- Addresses with no meaningful address content are removed.
+- `personal.addresses.addressTypeId` is required for every remaining address.
+- If `addressTypeId` is missing or blank, that address is discarded and logged as a data issue.
+- Only one address per `addressTypeId` is allowed.
+- If duplicate `addressTypeId` values are present, the first address is kept, later duplicates are discarded, and each discard is logged as a data issue.
+- Exactly one address is normalized to `primaryAddress=true`:
+    - If none are primary, the first remaining address is set to primary.
+    - If multiple are primary, only the first remains primary and the rest are set to false (also logged as a data issue).
+
+```{note}
+If your source data can contain multiple addresses, map a valid `addressTypeId` for each one to avoid unexpected address drops.
+```
+
 ## Mapping Multiple Departments
 
 To map multiple departments for a user, include all legacy values in the same column, sub-delimited with the `multi_field_delimiter` value from your `libraryConfiguration`:

--- a/src/folio_migration_tools/migration_tasks/user_transformer.py
+++ b/src/folio_migration_tools/migration_tasks/user_transformer.py
@@ -291,15 +291,15 @@ class UserTransformer(MigrationTaskBase):
     @staticmethod
     def clean_user(folio_user, index_or_id):
         valid_addresses = remove_empty_addresses(folio_user)
+        valid_addresses = remove_addresses_missing_type_id(valid_addresses, index_or_id)
+        valid_addresses = remove_duplicate_address_types(valid_addresses, index_or_id)
         # Make sure the user has exactly one primary address
         if valid_addresses:
             primary_true = find_primary_addresses(valid_addresses)
             if len(primary_true) < 1:
                 valid_addresses[0]["primaryAddress"] = True
             elif len(primary_true) > 1:
-                logging.log(
-                    26,
-                    "DATA ISSUE\t%s\t%s\t%s",
+                Helper.log_data_issue(
                     index_or_id,
                     "Too many addresses mapped as primary. Setting first one to primary.",
                     primary_true,
@@ -324,6 +324,54 @@ def remove_empty_addresses(folio_user):
             if address_fields:
                 valid_addresses.append(address)
     return valid_addresses
+
+
+def normalize_address_type_id(address):
+    address_type_id = address.get("addressTypeId")
+    if isinstance(address_type_id, str):
+        address_type_id = address_type_id.strip()
+        return address_type_id if address_type_id else None
+    return address_type_id
+
+
+def remove_addresses_missing_type_id(addresses, index_or_id):
+    addresses_with_type = []
+    for address in addresses:
+        normalized_type_id = normalize_address_type_id(address)
+        if normalized_type_id is None:
+            Helper.log_data_issue(
+                index_or_id,
+                "personal.addresses.addressTypeId is required. Discarding address.",
+                address,
+            )
+            continue
+        address["addressTypeId"] = normalized_type_id
+        addresses_with_type.append(address)
+    return addresses_with_type
+
+
+def remove_duplicate_address_types(addresses, index_or_id):
+    seen_type_ids = {}
+    deduplicated_addresses = []
+    for address in addresses:
+        address_type_id = address.get("addressTypeId")
+        if address_type_id in seen_type_ids:
+            Helper.log_data_issue(
+                index_or_id,
+                (
+                    "Duplicate personal.addresses.addressTypeId detected. "
+                    "Discarding duplicate address."
+                ),
+                {
+                    "addressTypeId": address_type_id,
+                    "keptAddress": seen_type_ids[address_type_id],
+                    "discardedAddress": address,
+                },
+            )
+            continue
+        seen_type_ids[address_type_id] = address
+        deduplicated_addresses.append(address)
+    return deduplicated_addresses
 
 
 def find_primary_addresses(addresses):

--- a/tests/test_user_transformer.py
+++ b/tests/test_user_transformer.py
@@ -19,8 +19,18 @@ def test_clean_user_all_false():
     folio_user = {
         "personal": {
             "addresses": [
-                {"id": "some id", "addressLine1": "addressLine1", "primaryAddress": False},
-                {"id": "some other id", "addressLine1": "addressLine1", "primaryAddress": False},
+                {
+                    "id": "some id",
+                    "addressLine1": "addressLine1",
+                    "addressTypeId": "home",
+                    "primaryAddress": False,
+                },
+                {
+                    "id": "some other id",
+                    "addressLine1": "addressLine1",
+                    "addressTypeId": "work",
+                    "primaryAddress": False,
+                },
             ],
             "metadata": "hm",
         }
@@ -38,8 +48,18 @@ def test_clean_user_all_false_one_string():
     folio_user = {
         "personal": {
             "addresses": [
-                {"id": "some id", "addressLine1": "addressLine1", "primaryAddress": False},
-                {"id": "some other id", "addressLine1": "addressLine1", "primaryAddress": "False"},
+                {
+                    "id": "some id",
+                    "addressLine1": "addressLine1",
+                    "addressTypeId": "home",
+                    "primaryAddress": False,
+                },
+                {
+                    "id": "some other id",
+                    "addressLine1": "addressLine1",
+                    "addressTypeId": "work",
+                    "primaryAddress": "False",
+                },
             ],
             "metadata": "hm",
         }
@@ -63,8 +83,18 @@ def test_clean_user_all_true():
     folio_user = {
         "personal": {
             "addresses": [
-                {"id": "some id", "addressLine1": "addressLine1", "primaryAddress": True},
-                {"id": "some other id", "addressLine1": "addressLine1", "primaryAddress": "True"},
+                {
+                    "id": "some id",
+                    "addressLine1": "addressLine1",
+                    "addressTypeId": "home",
+                    "primaryAddress": True,
+                },
+                {
+                    "id": "some other id",
+                    "addressLine1": "addressLine1",
+                    "addressTypeId": "work",
+                    "primaryAddress": "True",
+                },
             ]
         }
     }
@@ -81,8 +111,12 @@ def test_clean_user_no_primary_info():
     folio_user = {
         "personal": {
             "addresses": [
-                {"id": "some id", "addressLine1": "addressLine1"},
-                {"id": "some other id", "addressLine1": "addressLine1"},
+                {"id": "some id", "addressLine1": "addressLine1", "addressTypeId": "home"},
+                {
+                    "id": "some other id",
+                    "addressLine1": "addressLine1",
+                    "addressTypeId": "work",
+                },
             ]
         }
     }
@@ -99,7 +133,7 @@ def test_clean_user_no_real_address_data():
     folio_user = {
         "personal": {
             "addresses": [
-                {"id": "some id", "addressLine1": "addressLine1"},
+                {"id": "some id", "addressLine1": "addressLine1", "addressTypeId": "home"},
                 {"id": "some other id", "primaryAddress": True, "addressTypeId": "some type"},
             ]
         }
@@ -202,3 +236,86 @@ def test_find_primary_addresses_all_missing():
     assert len(primary) == 0
     for addr in addresses:
         assert addr["primaryAddress"] is False
+
+
+def test_clean_user_missing_address_type_discarded_and_logged(caplog):
+    caplog.set_level(26)
+    folio_user = {
+        "personal": {
+            "addresses": [
+                {"id": "missing-type", "addressLine1": "Address 1"},
+                {
+                    "id": "valid",
+                    "addressLine1": "Address 2",
+                    "addressTypeId": "home",
+                    "primaryAddress": False,
+                },
+            ]
+        }
+    }
+
+    UserTransformer.clean_user(folio_user, "u-1")
+
+    assert len(folio_user["personal"]["addresses"]) == 1
+    assert folio_user["personal"]["addresses"][0]["id"] == "valid"
+    assert folio_user["personal"]["addresses"][0]["primaryAddress"] is True
+    assert "personal.addresses.addressTypeId is required. Discarding address." in caplog.text
+
+
+def test_clean_user_blank_address_type_discarded_and_logged(caplog):
+    caplog.set_level(26)
+    folio_user = {
+        "personal": {
+            "addresses": [
+                {
+                    "id": "blank-type",
+                    "addressLine1": "Address 1",
+                    "addressTypeId": "   ",
+                },
+                {
+                    "id": "valid",
+                    "addressLine1": "Address 2",
+                    "addressTypeId": "work",
+                    "primaryAddress": False,
+                },
+            ]
+        }
+    }
+
+    UserTransformer.clean_user(folio_user, "u-2")
+
+    assert len(folio_user["personal"]["addresses"]) == 1
+    assert folio_user["personal"]["addresses"][0]["id"] == "valid"
+    assert "personal.addresses.addressTypeId is required. Discarding address." in caplog.text
+
+
+def test_clean_user_duplicate_address_type_discards_second_and_logs(caplog):
+    caplog.set_level(26)
+    folio_user = {
+        "personal": {
+            "addresses": [
+                {
+                    "id": "first",
+                    "addressLine1": "Address 1",
+                    "addressTypeId": "home",
+                    "primaryAddress": False,
+                },
+                {
+                    "id": "second",
+                    "addressLine1": "Address 2",
+                    "addressTypeId": "home",
+                    "primaryAddress": True,
+                },
+            ]
+        }
+    }
+
+    UserTransformer.clean_user(folio_user, "u-3")
+
+    assert len(folio_user["personal"]["addresses"]) == 1
+    assert folio_user["personal"]["addresses"][0]["id"] == "first"
+    assert folio_user["personal"]["addresses"][0]["primaryAddress"] is True
+    assert (
+        "Duplicate personal.addresses.addressTypeId detected. Discarding duplicate address."
+        in caplog.text
+    )


### PR DESCRIPTION
## Purpose
User transformations should not output invalid or ambiguous address data. This change enforces required `personal.addresses.addressTypeId` values and removes duplicate address type entries so each user has at most one address per type.

## Changes Made in this PR
- Added cleanup steps in `UserTransformer.clean_user` to:
  - discard addresses missing or blank `addressTypeId`
  - discard duplicate `addressTypeId` entries, keeping the first occurrence
- Logged each discarded address as a data issue using the existing `Helper.log_data_issue` mechanism.
- Kept existing primary-address normalization behavior, and aligned primary-address data issue logging with `Helper.log_data_issue`.
- Added/updated unit tests covering:
  - missing/blank `addressTypeId` discard behavior
  - duplicate `addressTypeId` dedupe behavior
  - existing clean-user expectations under the new required-type rule
- Updated UserTransformer docs with an "Address Validation Rules" section.

## Code Review Specifics
- Please focus review on cleanup order and behavior in `clean_user`:
  - remove empty addresses
  - enforce required `addressTypeId`
  - dedupe by `addressTypeId`
  - normalize primary address
- Please also verify data issue log messages are clear for operators.

## Task Checklist
- [ ] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [ ] Ran test suite: `nox -rs tests`
- [ ] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [x] Documentation updated

## Warning Checklist
- [ ] New dependencies added
- [ ] Includes breaking changes

## How to Verify
1. Run targeted tests:
   - `python -m pytest tests/test_user_transformer.py -q`
2. Confirm test cases pass for:
   - missing/blank `addressTypeId` addresses are discarded
   - duplicate `addressTypeId` addresses are discarded after first occurrence
   - exactly one address remains primary when addresses remain
3. Optional manual behavior check:
   - Provide user input mapping that emits two addresses with same `addressTypeId`
   - Verify only first is retained in transformed output and a data issue is logged

## Open Questions
- [ ] Should duplicate `addressTypeId` comparison be case-insensitive for non-UUID source values?

## Learn Anything Cool?
None to add for this change.