### PR TITLE
Docs/add docs details for user notes transformation

### DIFF
--- a/docs/source/tasks/items_transformer.md
+++ b/docs/source/tasks/items_transformer.md
@@ -202,7 +202,7 @@ Unlike BibsTransformer and the Holdings transformers, ItemsTransformer does not 
 The ItemsTransformer supports creating FOLIO `boundwithPart` records to link items to multiple holdings. The `boundwithFlavor` parameter determines how relationships are loaded and resolved. Supported values are `"voyager"` (default) and `"aleph"`.
 
 ```{note}
-For III/Sierra/Millennium-style boundwiths — where items link to multiple bibs directly in the source data — boundwith handling is performed at the holdings level by [HoldingsCsvTransformer](holdings_csv_transformer#boundwith-handling), not here. No `boundwithFlavor` or `boundwithRelationshipFilePath` is needed in that case.
+For III/Sierra/Millennium-style boundwiths — where items link to multiple bibs directly in the source data — boundwith handling is performed at the holdings level by [HoldingsCsvTransformer](holdings_csv_transformer.md#boundwith-handling), not here. No `boundwithFlavor` or `boundwithRelationshipFilePath` is needed in that case.
 ```
 
 #### Voyager-style boundwiths

--- a/docs/source/tasks/user_transformer.md
+++ b/docs/source/tasks/user_transformer.md
@@ -35,6 +35,7 @@ Transform delimited (CSV/TSV) data into FOLIO User records with support for patr
 | `departmentsMapPath` | string | No | TSV file mapping user departments |
 | `addressTypeMapPath` | string | No | TSV file mapping address types |
 | `preferredContactTypeMapPath` | string | No | TSV file mapping preferred contact types |
+| `removeIdAndRequestPreferences` | boolean | No | Remove `id` and `requestPreference` from output. Leave this `false` when mapping user notes, because linked note creation depends on the transformed user `id`. |
 | `removeRequestPreferences` | boolean | No | Remove request preference data from output |
 | `userFile` | object | Yes | Source file definition with `file_name` |
 
@@ -99,6 +100,10 @@ Create a JSON mapping file in `mapping_files/`:
 
 ```{important}
 The `legacyIdentifier` field is required and must map to a unique value in your source data.
+```
+
+```{warning}
+If your user mapping includes `notes[...]` fields, do not enable `removeIdAndRequestPreferences`. User note records are linked using the transformed user `id`, so the transformed user output must retain `id` when notes are being mapped.
 ```
 
 ### Reference Data Mapping Files
@@ -230,6 +235,24 @@ Files are created in `iterations/<iteration>/results/`:
     }
 }
 ```
+
+### Remove ID And Request Preferences
+
+```json
+{
+    "name": "transform_users",
+    "migrationTaskType": "UserTransformer",
+    "userMappingFileName": "user_mapping.json",
+    "groupMapPath": "patron_groups.tsv",
+    "useGroupMap": true,
+    "removeIdAndRequestPreferences": true,
+    "userFile": {
+        "file_name": "patrons.tsv"
+    }
+}
+```
+
+Use this only when your transformed user records will not also be used to create linked user notes.
 
 ## Running the Task
 


### PR DESCRIPTION
## Purpose
<!-- Why are you making this change?  Provide the reviewer and future readers the cause that gave rise to this pull request. Include enough detail for a developer from another team to reconstruct the necessary context merely by reading this section.

You can link to an Issue by saying something like "Fixes #1" -->

## Changes Made in this PR
<!-- How does this change fulfill the purpose? It's best to talk high-level strategy and avoid restating the commit history. The goal is not only to explain what you did, but help other developers work with your solution in the future. -->

## Code Review Specifics
<!-- Is this change trivial, or this project still in MVP just push along mode? Or is there an area you'd really like a thorough review? E.g:
- This just needs approval
- Read the code, make suggestions
- Fire it up and make sure it works
-
-->

## Task Checklist
<!-- This serves as gentle reminder for common tasks. Confirm these are done and check all that apply. -->
- [ ] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [ ] Tests cover new or modified code.
- [ ] Ran test suite: `nox -rs tests`
- [ ] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [ ] Documentation updated

## Warning Checklist
<!-- These items warn others about potential issues. Check any that apply. -->
- [ ] New dependencies added
- [ ] Includes breaking changes

## How to Verify
<!-- Provide the steps necessary to verify the changes made to resolve the ticket acceptance criteria -->

## Open Questions
<!-- *OPTIONAL*
  - [ ] Use GitHub checklists to prompt discussion around questions you may have with your approach. When solved, check the box and explain the answer.
-->

## Learn Anything Cool?
<!-- *OPTIONAL* Crafting a solution sometimes requires a lot of research. Don't let all that hard work go to waste! Use this opportunity to share what you learned. Add links to blog posts, patterns, libraries, and other resources used to solve this problem. -->
