### PR TITLE
Fix order line path mapping for nested objects and JSON-safe field mapping errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "folio_migration_tools"
-version = "1.12.3"
+version = "1.12.4"
 description =  "A tool allowing you to migrate data from legacy ILS:s (Library systems) into FOLIO LSP"
 authors = [
 	{name = "Theodor Tolstoy", email = "github.teddes@tolstoy.se"},

--- a/src/folio_migration_tools/mapper_base.py
+++ b/src/folio_migration_tools/mapper_base.py
@@ -248,7 +248,8 @@ class MapperBase:
             ) from exception
 
     def handle_transformation_field_mapping_error(self, index_or_id, error):
-        self.migration_report.add("FieldMappingErrors", error)
+        error_key = f"{error.message}\t{error.data_value}"
+        self.migration_report.add("FieldMappingErrors", error_key)
         error.index_or_id = error.index_or_id or index_or_id
         error.log_it()
         self.migration_report.add_general_statistics(i18n_t("Field Mapping Errors found"))

--- a/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
+++ b/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
@@ -561,6 +561,12 @@ class MappingFileMapperBase(MapperBase):
         index_or_id,
         level: int,
     ):
+        def _normalize_local_object_path(path: str) -> str:
+            # When mapping nested object fields under an array item (for example,
+            # "poLines[0].cost.currency") into a temporary item object, keep only
+            # the local path segment ("cost.currency").
+            return path.split("].", 1)[1] if "]." in path else path
+
         temp_object: dict = {}
         for child_property_name, child_property in schema_property["properties"].items():
             sub_prop_path = f"{schema_property_name}.{child_property_name}"
@@ -607,12 +613,12 @@ class MappingFileMapperBase(MapperBase):
                 if p := self.get_prop(
                     legacy_object, sub_prop_path, index_or_id, child_property.get("default", "")
                 ):
-                    set_at_path(folio_object, sub_prop_path, p)
+                    set_at_path(folio_object, _normalize_local_object_path(sub_prop_path), p)
                 # temp_object[child_property_name] = p
             elif p := self.get_prop(
                 legacy_object, sub_prop_path, index_or_id, child_property.get("default", "")
             ):
-                set_at_path(folio_object, sub_prop_path, p)
+                set_at_path(folio_object, _normalize_local_object_path(sub_prop_path), p)
         if temp_object:
             set_deep(folio_object, schema_property_name, temp_object)
             # folio_object[schema_property_name] = temp_object

--- a/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
+++ b/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
@@ -604,16 +604,15 @@ class MappingFileMapperBase(MapperBase):
                     index_or_id,
                 )
             elif child_property.get("type", "") in ["string", "number", "integer"]:
-                path = sub_prop_path.split("].")[-1]
                 if p := self.get_prop(
                     legacy_object, sub_prop_path, index_or_id, child_property.get("default", "")
                 ):
-                    set_deep(folio_object, f"{path}", p)
+                    set_at_path(folio_object, sub_prop_path, p)
                 # temp_object[child_property_name] = p
             elif p := self.get_prop(
                 legacy_object, sub_prop_path, index_or_id, child_property.get("default", "")
             ):
-                set_deep(folio_object, sub_prop_path, p)
+                set_at_path(folio_object, sub_prop_path, p)
         if temp_object:
             set_deep(folio_object, schema_property_name, temp_object)
             # folio_object[schema_property_name] = temp_object

--- a/tests/test_mapping_file_mapper_base.py
+++ b/tests/test_mapping_file_mapper_base.py
@@ -1,6 +1,7 @@
 import csv
 import functools
 import io
+import json
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -9,6 +10,7 @@ from folio_uuid.folio_namespaces import FOLIONamespaces
 from folioclient import FolioClient
 
 from folio_migration_tools.custom_exceptions import (
+    TransformationFieldMappingError,
     TransformationProcessError,
     TransformationRecordFailedError,
 )
@@ -6323,4 +6325,21 @@ def test_validate_array_item_missing_required_log_it_output(
     assert "PO-12345" in log_msg
     assert "Required properties missing in poLines item" in log_msg
     assert "orderFormat" in log_msg
-    assert "source" in log_msg
+
+
+def test_field_mapping_errors_report_is_json_serializable(mocked_file_mapper):
+    err = TransformationFieldMappingError(
+        index_or_id="rec-1",
+        message="Required properties missing in poLines item",
+        data_value="orderFormat,source",
+    )
+
+    mocked_file_mapper.handle_transformation_field_mapping_error("rec-1", err)
+
+    output = io.StringIO()
+    mocked_file_mapper.migration_report.write_json_report(output)
+    payload = json.loads(output.getvalue())
+
+    assert "FieldMappingErrors" in payload
+    assert isinstance(payload["FieldMappingErrors"], dict)
+    assert payload["FieldMappingErrors"]["Required properties missing in poLines item\torderFormat,source"] == 1

--- a/tests/test_mapping_file_mapper_base.py
+++ b/tests/test_mapping_file_mapper_base.py
@@ -6343,3 +6343,62 @@ def test_field_mapping_errors_report_is_json_serializable(mocked_file_mapper):
     assert "FieldMappingErrors" in payload
     assert isinstance(payload["FieldMappingErrors"], dict)
     assert payload["FieldMappingErrors"]["Required properties missing in poLines item\torderFormat,source"] == 1
+
+
+def test_nested_object_fields_under_array_item_are_local_to_item(
+    mocked_folio_client, mocked_file_mapper
+):
+    schema = {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {
+            "id": {"type": "string"},
+            "lines": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string"},
+                        "source": {"type": "string"},
+                        "cost": {
+                            "type": "object",
+                            "properties": {
+                                "currency": {"type": "string"},
+                                "listUnitPrice": {"type": "number"},
+                            },
+                        },
+                    },
+                    "required": ["title", "source"],
+                },
+            },
+        },
+        "required": [],
+    }
+    record = {
+        "id": "rec-1",
+        "line_title": "Example title",
+        "line_source": "API",
+    }
+    the_map = {
+        "data": [
+            {"folio_field": "legacyIdentifier", "legacy_field": "id", "value": "", "description": ""},
+            {"folio_field": "lines[0].title", "legacy_field": "line_title", "value": "", "description": ""},
+            {"folio_field": "lines[0].source", "legacy_field": "line_source", "value": "", "description": ""},
+            {"folio_field": "lines[0].cost.currency", "legacy_field": "", "value": "USD", "description": ""},
+            {"folio_field": "lines[0].cost.listUnitPrice", "legacy_field": "", "value": 10.5, "description": ""},
+        ]
+    }
+    mapper = MappingFileMapperBase(
+        mocked_folio_client,
+        schema,
+        the_map,
+        None,
+        FOLIONamespaces.orders,
+        mocked_classes.get_mocked_library_config(),
+        mocked_file_mapper.task_configuration,
+    )
+
+    folio_rec, _ = mapper.do_map(record, record["id"], FOLIONamespaces.orders)
+
+    assert folio_rec["lines"][0]["cost"]["currency"] == "USD"
+    assert folio_rec["lines"][0]["cost"]["listUnitPrice"] == 10.5

--- a/tests/test_orders_mapper.py
+++ b/tests/test_orders_mapper.py
@@ -132,6 +132,18 @@ def mapper(pytestconfig) -> CompositeOrderMapper:
                 "description": "",
             },
             {
+                "folio_field": "compositePoLines[0].details.subscriptionFrom",
+                "legacy_field": "SUBSCRIPTION FROM",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "compositePoLines[0].details.subscriptionTo",
+                "legacy_field": "SUBSCRIPTION TO",
+                "value": "",
+                "description": "",
+            },
+            {
                 "folio_field": "compositePoLines[0].source",
                 "legacy_field": "",
                 "value": "API",
@@ -363,6 +375,8 @@ def test_composite_order_with_one_pol_mapping(mapper):
         "copies": "2",
         "location": "order",
         "acqmethod": "p",
+        "SUBSCRIPTION FROM": "2026-01-01",
+        "SUBSCRIPTION TO": "2026-12-31",
     }
     composite_order_with_pol, idx = mapper.do_map(
         data, data["order_number"], FOLIONamespaces.orders
@@ -385,6 +399,8 @@ def test_composite_order_with_one_pol_mapping(mapper):
         == "184aae84-a5bf-4c6a-85ba-4a7c73026cd5"
     )
     assert composite_order_with_pol[pol_key][0]["locations"][0]["quantity"] == "2"
+    assert composite_order_with_pol[pol_key][0]["details"]["subscriptionFrom"] == "2026-01-01"
+    assert composite_order_with_pol[pol_key][0]["details"]["subscriptionTo"] == "2026-12-31"
 
 
 def test_one_order_one_pol_multiple_notes(mapper):


### PR DESCRIPTION
## Purpose
This PR fixes two regressions encountered during order transformations.

1. Array-indexed mapping paths were being treated inconsistently in nested object mapping, which could create malformed keys and prevent expected nested objects (such as cost and details) from being written under the purchase order line item.
2. Field mapping errors were stored in the migration report using exception objects as dictionary keys, which broke JSON serialization during wrap-up.

These issues surfaced while validating order mappings for nested line fields, including details.subscriptionFrom, details.subscriptionTo, and cost subfields.

## Changes Made in this PR
1. Updated field-mapping error handling to store a string key instead of an exception object in FieldMappingErrors.
2. Updated nested object path handling in MappingFileMapperBase.map_object_props so array-item object paths are normalized to local item paths (for example, lines[0].cost.currency becomes cost.currency when writing into the current item object).
3. Added regression coverage for:
- JSON-serializable FieldMappingErrors report output.
- Nested object fields under array items mapping into the correct local object (cost object created under the line item).
- Order details mappings under compositePoLines line items (subscriptionFrom/subscriptionTo).

Changed files:
- mapper_base.py
- mapping_file_mapper_base.py
- test_mapping_file_mapper_base.py
- test_orders_mapper.py

## Code Review Specifics
Please review:
1. The path normalization behavior in map_object_props for nested object fields under array items.
2. The new FieldMappingErrors key format to confirm it preserves useful reporting detail.
3. The regression tests for coverage of both serialization and nested object placement under array items.

## Task Checklist
- [ ] Ran nox -rs safety.
- [x] Ran pre-commit run --all-files
- [x] Tests cover new or modified code.
- [x] Ran test suite: nox -rs tests
- [x] Code runs and outputs default usage info: cd src; poetry run python3 -m folio_migration_tools -h
- [ ] Documentation updated

## Warning Checklist
- [ ] New dependencies added
- [ ] Includes breaking changes

## How to Verify
1. Run focused mapper regression tests:
source .env && python -m pytest -q test_mapping_file_mapper_base.py -k "nested_object_fields_under_array_item_are_local_to_item or field_mapping_errors_report_is_json_serializable"

2. Run order mapper test that validates details fields on line items:
source .env && python -m pytest -q test_orders_mapper.py -k "test_composite_order_with_one_pol_mapping"

3. Validate behavior in a transform run:
- Confirm no literal compositPoLines-style key appears.
- Confirm nested objects such as cost and details exist under the first po line object (compositePoLines or poLines, depending on schema version).
- Confirm raw report JSON writes successfully without TypeError for FieldMappingErrors keys.

## Open Questions
- [ ] Should FieldMappingErrors include record id in the key to improve aggregation context, or should that remain only in logs?

## Learn Anything Cool?
Path handling for nested mappings in mixed dict/list structures is safest when writes are context-aware:
1. Use full path parsing for root-object writes.
2. Use local-path normalization when writing into temporary per-item array objects.
3. Keep report aggregation keys JSON-safe by reducing rich objects to stable string identifiers.