### PR TITLE
Fix/orders custom fields mapping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "folio_migration_tools"
-version = "1.12.4"
+version = "1.12.5"
 description =  "A tool allowing you to migrate data from legacy ILS:s (Library systems) into FOLIO LSP"
 authors = [
 	{name = "Theodor Tolstoy", email = "github.teddes@tolstoy.se"},

--- a/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
@@ -12,6 +12,7 @@ import re
 import sys
 import urllib.parse
 import uuid
+from typing import Any
 
 import httpx
 import i18n
@@ -105,6 +106,11 @@ class CompositeOrderMapper(MappingFileMapperBase):
                         legacy_key, self.po_lines_key, 1
                     )
 
+        # customFields in orders schemas are typically open objects with
+        # additionalProperties and no explicit properties; add mapped keys so
+        # the generic object mapper can traverse and populate them.
+        self._inject_mapped_custom_fields_into_schema(composite_order_map)
+
         super().__init__(
             folio_client,
             self.composite_order_schema,
@@ -156,6 +162,82 @@ class CompositeOrderMapper(MappingFileMapperBase):
             True,
         )
         self.notes_mapper.migration_report = self.migration_report
+
+    @staticmethod
+    def _ensure_custom_fields_object_schema(
+        parent_schema: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        if not isinstance(parent_schema, dict):
+            return None
+        properties = parent_schema.get("properties")
+        if not isinstance(properties, dict):
+            return None
+        custom_fields_schema = properties.get("customFields")
+        if custom_fields_schema is None:
+            custom_fields_schema = {
+                "type": "object",
+                "description": "dynamically added custom fields",
+                "additionalProperties": True,
+                "properties": {},
+            }
+            properties["customFields"] = custom_fields_schema
+        elif "properties" not in custom_fields_schema or not isinstance(
+            custom_fields_schema.get("properties"), dict
+        ):
+            custom_fields_schema["properties"] = {}
+
+        return custom_fields_schema
+
+    @staticmethod
+    def _collect_order_custom_field_name(folio_field: str) -> str:
+        if not folio_field.startswith("customFields."):
+            return ""
+        field_name = folio_field.split(".", 1)[1]
+        return field_name if field_name and "." not in field_name else ""
+
+    def _collect_pol_custom_field_name(self, folio_field: str) -> str:
+        pol_pattern = re.compile(
+            rf"{re.escape(self.po_lines_key)}\[\d+\]\.customFields\.([^.]+)$"
+        )
+        pol_match = pol_pattern.match(folio_field)
+        return pol_match.group(1) if pol_match else ""
+
+    @staticmethod
+    def _inject_custom_fields_properties(
+        schema_root: dict[str, Any], custom_field_names: set[str]
+    ) -> None:
+        if not custom_field_names:
+            return
+        custom_fields_schema = CompositeOrderMapper._ensure_custom_fields_object_schema(
+            schema_root
+        )
+        if custom_fields_schema is None:
+            return
+        for field_name in custom_field_names:
+            custom_fields_schema["properties"][field_name] = {
+                "type": "string",
+                "description": "dynamically added custom prop",
+            }
+
+    def _inject_mapped_custom_fields_into_schema(self, composite_order_map: dict) -> None:
+        order_custom_fields = set()
+        pol_custom_fields = set()
+
+        for map_entry in composite_order_map.get("data", []):
+            folio_field = map_entry.get("folio_field", "")
+            if order_field := self._collect_order_custom_field_name(folio_field):
+                order_custom_fields.add(order_field)
+            if pol_field := self._collect_pol_custom_field_name(folio_field):
+                pol_custom_fields.add(pol_field)
+
+        self._inject_custom_fields_properties(self.composite_order_schema, order_custom_fields)
+
+        po_lines_schema = (
+            self.composite_order_schema.get("properties", {})
+            .get(self.po_lines_key, {})
+            .get("items", {})
+        )
+        self._inject_custom_fields_properties(po_lines_schema, pol_custom_fields)
 
     def get_prop(self, legacy_order, folio_prop_name: str, index_or_id, schema_default_value):
         if folio_prop_name.endswith(".acquisitionMethod"):

--- a/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
@@ -196,9 +196,7 @@ class CompositeOrderMapper(MappingFileMapperBase):
         return field_name if field_name and "." not in field_name else ""
 
     def _collect_pol_custom_field_name(self, folio_field: str) -> str:
-        pol_pattern = re.compile(
-            rf"{re.escape(self.po_lines_key)}\[\d+\]\.customFields\.([^.]+)$"
-        )
+        pol_pattern = re.compile(rf"{re.escape(self.po_lines_key)}\[\d+\]\.customFields\.([^.]+)$")
         pol_match = pol_pattern.match(folio_field)
         return pol_match.group(1) if pol_match else ""
 

--- a/tests/test_orders_mapper.py
+++ b/tests/test_orders_mapper.py
@@ -1,4 +1,5 @@
 import logging
+from copy import deepcopy
 
 import pytest
 from folio_uuid.folio_namespaces import FOLIONamespaces
@@ -498,6 +499,61 @@ def test_multiple_pols_with_one_or_more_notes(mapper):
         str(mapper.extradata_writer.cache).count(composite_orders[1][pol_key][0]["id"])
         == 1
     )
+
+
+def test_composite_order_mapping_with_custom_fields(mapper):
+    custom_map = deepcopy(mapper.record_map)
+    pol_key = mapper.po_lines_key
+    custom_map["data"].extend(
+        [
+            {
+                "folio_field": "customFields.orderSource",
+                "legacy_field": "order_custom",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": f"{pol_key}[0].customFields.lineTag",
+                "legacy_field": "line_custom",
+                "value": "",
+                "description": "",
+            },
+        ]
+    )
+
+    custom_mapper = CompositeOrderMapper(
+        mapper.folio_client,
+        mapper.library_configuration,
+        mapper.task_configuration,
+        custom_map,
+        mapper.organizations_id_map,
+        mapper.instance_id_map,
+        mapper.acquisitions_methods_mapping.map,
+        "",
+        "",
+        "",
+        mapper.location_mapping.map,
+        "",
+        "",
+    )
+
+    data = {
+        "order_number": "o125",
+        "vendor": "EBSCO",
+        "type": "One-Time",
+        "TITLE": "Mapped with custom fields",
+        "bibnumber": "1",
+        "copies": "1",
+        "location": "order",
+        "acqmethod": "p",
+        "order_custom": "donation",
+        "line_custom": "rush",
+    }
+
+    mapped_order, _ = custom_mapper.do_map(data, data["order_number"], FOLIONamespaces.orders)
+
+    assert mapped_order["customFields"]["orderSource"] == "donation"
+    assert mapped_order[pol_key][0]["customFields"]["lineTag"] == "rush"
 
 
 def test_perform_additional_mapping_get_org_from_folio(mapper):


### PR DESCRIPTION
## Purpose
Orders customFields mappings defined in the JSON mapping file were not being applied to transformed order output. This caused configured custom fields to be silently dropped for both top-level purchase orders and embedded purchase order lines.

## Changes Made in this PR
- Added schema injection logic in the orders mapper to dynamically register mapped customFields keys before transformation.
- Supported both mapping paths:
  - top-level order custom fields
  - embedded PO line custom fields
- Kept compatibility with both schema variants for line arrays by using the detected line key.
- Added a regression test that verifies custom field mapping is preserved in output for:
  - order-level custom fields
  - PO line-level custom fields

## Code Review Specifics
- Please focus review on:
  - Dynamic schema mutation safety and maintainability
  - Behavior across schema variants for purchase order lines
  - Regression test realism and coverage of expected mapping behavior

## Task Checklist
- [ ] Ran nox -rs safety
- [ ] Ran pre-commit run --all-files
- [x] Tests cover new or modified code
- [x] Ran test suite: nox -rs tests
- [x] Code runs and outputs default usage info: cd src; poetry run python3 -m folio_migration_tools -h
- [ ] Documentation updated

## Warning Checklist
- [ ] New dependencies added
- [ ] Includes breaking changes

## How to Verify
1. Check out branch fix/orders-custom-fields-mapping.
2. Run targeted regression tests:

    pytest test_orders_mapper.py

3. Confirm the custom fields test passes and validates that mapped custom fields are present in transformed order output for both:
   - customFields.<field>
   - line-array customFields.<field>

## Open Questions
- [ ] Should customFields support additional non-string types from mapping configuration, or remain string-only as currently implemented?

## Learn Anything Cool?
Schema-defined open objects with empty properties can still block mapper traversal if mapping logic depends on explicit schema properties. Dynamically injecting mapped keys into schema is an effective way to preserve strict mapper behavior while enabling custom field extensibility.