### PR TITLE
Add name-based order bill-to and ship-to mapping

### DIFF
--- a/docs/source/mapping_file_based_mapping.md
+++ b/docs/source/mapping_file_based_mapping.md
@@ -343,3 +343,5 @@ Please update your mapping file with valid note type names or UUIDs.
 ```
 
 This validation ensures that mapping configuration errors are caught immediately, rather than during data processing when iteration is more costly.
+
+Record type-specific mapping behavior and validation (for example Orders-only fields) is documented in the corresponding task pages under [Tasks](tasks/index).

--- a/docs/source/migration_reports.md
+++ b/docs/source/migration_reports.md
@@ -182,6 +182,8 @@ Transforms vendor/organization data for acquisitions.
 #### OrdersTransformer
 Transforms purchase order data.
 
+For Orders-specific address mapping behavior and validation/error handling for `billTo`/`shipTo`, see [OrdersTransformer](tasks/orders_transformer#validation-and-error-reporting-for-billtoshipto).
+
 | Report Section | Description |
 |----------------|-------------|
 | GeneralStatistics | Order and order line counts |

--- a/docs/source/tasks/orders_transformer.md
+++ b/docs/source/tasks/orders_transformer.md
@@ -179,7 +179,7 @@ Address name matching is case-insensitive and trims surrounding whitespace. If a
 
 Both `value` and `fallback_value` are supported for name-based address mapping.
 
-- If `value` or `fallback_value` contains a UUID, it is accepted as-is.
+- If `value` or `fallback_value` contains a UUID, it must match a valid tenant address configuration entry `id`.
 - If `value` or `fallback_value` contains a name, it is resolved against `tenant.addresses`.
 
 Validation happens at two stages:

--- a/docs/source/tasks/orders_transformer.md
+++ b/docs/source/tasks/orders_transformer.md
@@ -135,6 +135,60 @@ Orders in FOLIO consist of a Purchase Order (header) with embedded Purchase Orde
 }
 ```
 
+## billTo and shipTo Address Mapping
+
+Orders support name-based mapping for `billTo` and `shipTo`.
+
+- In your orders field mapping file, map `billTo` and `shipTo` to legacy source fields that contain address names.
+- During transformation, the mapper resolves those names against tenant address settings from `/configurations/entries` where `module=="TENANT"` and `configName=="tenant.addresses"`.
+- The resulting FOLIO value written to `billTo`/`shipTo` is the address UUID from the configuration entry `id`.
+
+Example mapping entries:
+
+```json
+{
+    "folio_field": "billTo",
+    "legacy_field": "BILL_TO_NAME",
+    "value": ""
+},
+{
+    "folio_field": "shipTo",
+    "legacy_field": "SHIP_TO_NAME",
+    "value": ""
+}
+```
+
+Expected tenant configuration shape:
+
+```json
+{
+    "id": "e8532c88-ab56-461a-8ba8-ed18bf5e5c22",
+    "module": "TENANT",
+    "configName": "tenant.addresses",
+    "value": "{\"name\":\"Acquisitions\",\"address\":\"...\"}"
+}
+```
+
+In this example, if source data contains `Acquisitions`, the mapped UUID is `e8532c88-ab56-461a-8ba8-ed18bf5e5c22`.
+
+```{important}
+Address name matching is case-insensitive and trims surrounding whitespace. If a name cannot be resolved, the record fails with a data issue.
+```
+
+### Validation and Error Reporting for billTo/shipTo
+
+Both `value` and `fallback_value` are supported for name-based address mapping.
+
+- If `value` or `fallback_value` contains a UUID, it is accepted as-is.
+- If `value` or `fallback_value` contains a name, it is resolved against `tenant.addresses`.
+
+Validation happens at two stages:
+
+- **Startup validation (process-level):** hardcoded `value` and `fallback_value` entries for `billTo`/`shipTo` are validated when the mapper initializes. If any configured value is invalid, the task reports a transformation process error and halts.
+- **Per-record validation (record-level):** names coming from source data (for example from `legacy_field`) are validated during record transformation. If a name cannot be resolved, that record is marked as failed and logged as a data issue.
+
+The migration report includes record-level failures, and processing continues unless failure thresholds are exceeded by task configuration.
+
 ### Reference Data Mapping Files
 
 Reference data mapping files connect values from your legacy data to FOLIO reference data. See [Reference Data Mapping](../reference_data_mapping) for detailed documentation on how these files work.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "folio_migration_tools"
-version = "1.12.6"
+version = "1.12.7"
 description =  "A tool allowing you to migrate data from legacy ILS:s (Library systems) into FOLIO LSP"
 authors = [
 	{name = "Theodor Tolstoy", email = "github.teddes@tolstoy.se"},

--- a/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
@@ -304,21 +304,15 @@ class CompositeOrderMapper(MappingFileMapperBase):
         return ""
 
     @staticmethod
-    def _addresses_from_config_value(raw_value: Any) -> list[dict[str, Any]]:
+    def _address_from_config_value(raw_value: Any) -> dict[str, Any] | None:
         value = raw_value
         if isinstance(raw_value, str):
             try:
                 value = json.loads(raw_value)
             except json.JSONDecodeError:
-                return []
+                return None
 
-        if isinstance(value, dict):
-            if isinstance(value.get("addresses"), list):
-                return [a for a in value["addresses"] if isinstance(a, dict)]
-            return [value] if value else []
-        if isinstance(value, list):
-            return [a for a in value if isinstance(a, dict)]
-        return []
+        return value if isinstance(value, dict) else None
 
     def _load_order_addresses_by_name(self) -> dict[str, str]:
         entries = list(
@@ -335,11 +329,12 @@ class CompositeOrderMapper(MappingFileMapperBase):
             if not isinstance(entry_id, str) or not entry_id.strip():
                 continue
             entry_id = entry_id.strip()
-            addresses = self._addresses_from_config_value(entry.get("value"))
-            for address in addresses:
-                address_name = self._extract_address_name(address)
-                if address_name:
-                    addresses_by_name[address_name.lower()] = entry_id
+            address = self._address_from_config_value(entry.get("value"))
+            if not address:
+                continue
+            address_name = self._extract_address_name(address)
+            if address_name:
+                addresses_by_name[address_name.lower()] = entry_id
 
         if addresses_by_name:
             logger.info(
@@ -370,7 +365,37 @@ class CompositeOrderMapper(MappingFileMapperBase):
             f"Available addresses: {', '.join(sorted(self._order_addresses_by_name.keys()))}",
         )
 
+    def _check_order_address_value(
+        self,
+        value: Any,
+        address_names_by_name: dict[str, str],
+        address_ids: set[str],
+        folio_field: str,
+        field_type: str,
+    ) -> str | None:
+        if isinstance(value, str):
+            value = value.strip()
+        if not value:
+            return None
+
+        if self.is_uuid(value):
+            if value not in address_ids:
+                return (
+                    f"  - '{value}' (in field: {folio_field}, {field_type}) "
+                    "- UUID not found in tenant settings"
+                )
+            return None
+
+        if value.lower() not in address_names_by_name:
+            return (
+                f"  - '{value}' (in field: {folio_field}, {field_type}) "
+                "- name not found in tenant settings"
+            )
+
+        return None
+
     def _validate_hardcoded_order_address_values(self) -> None:
+        address_ids = set(self._order_addresses_by_name.values())
         invalid_values: list[str] = []
 
         for entry in self.record_map.get("data", []):
@@ -380,22 +405,26 @@ class CompositeOrderMapper(MappingFileMapperBase):
 
             for value_key in ("value", "fallback_value"):
                 mapped_value = entry.get(value_key)
-                if not mapped_value:
-                    continue
-                if self.is_uuid(mapped_value):
-                    continue
-                if mapped_value.lower().strip() not in self._order_addresses_by_name:
-                    invalid_values.append(f"- {folio_field} ({value_key}): '{mapped_value}'")
+                invalid = self._check_order_address_value(
+                    mapped_value,
+                    self._order_addresses_by_name,
+                    address_ids,
+                    folio_field,
+                    value_key,
+                )
+                if invalid:
+                    invalid_values.append(invalid)
 
         if invalid_values:
             available = ", ".join(sorted(self._order_addresses_by_name.keys()))
             raise TransformationProcessError(
                 "",
-                "Invalid order address values found in field mapping",
+                "Invalid order address values found in field mapping:",
                 "\n".join(
                     [
                         *invalid_values,
                         f"Available addresses: {available}",
+                        "Please update your mapping file with valid address names or UUIDs.",
                     ]
                 ),
             )

--- a/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
@@ -20,7 +20,10 @@ from folio_uuid.folio_uuid import FOLIONamespaces
 from folioclient import FolioClient
 from httpx import HTTPError
 
-from folio_migration_tools.custom_exceptions import TransformationRecordFailedError
+from folio_migration_tools.custom_exceptions import (
+    TransformationProcessError,
+    TransformationRecordFailedError,
+)
 from folio_migration_tools.helper import Helper
 from folio_migration_tools.library_configuration import LibraryConfiguration
 from folio_migration_tools.mapping_file_transformation.mapping_file_mapper_base import (
@@ -35,6 +38,8 @@ logger = logging.getLogger(__name__)
 
 
 class CompositeOrderMapper(MappingFileMapperBase):
+    TENANT_ADDRESSES_QUERY = '?query=(module=="TENANT" and configName=="tenant.addresses")'
+
     def __init__(
         self,
         folio_client: FolioClient,
@@ -151,6 +156,8 @@ class CompositeOrderMapper(MappingFileMapperBase):
             "code",
             "FundsMapping",
         )
+        self._order_addresses_by_name = self._load_order_addresses_by_name()
+        self._validate_hardcoded_order_address_values()
 
         self.folio_client: FolioClient = folio_client
         self.notes_mapper: NotesMapper = NotesMapper(
@@ -273,11 +280,125 @@ class CompositeOrderMapper(MappingFileMapperBase):
                 False,
             )
 
+        if folio_prop_name in ("billTo", "shipTo"):
+            raw = super().get_prop(
+                legacy_order,
+                folio_prop_name,
+                index_or_id,
+                schema_default_value,
+            )
+            return self._resolve_order_address_id(raw, folio_prop_name, index_or_id)
+
         mapped_value = super().get_prop(
             legacy_order, folio_prop_name, index_or_id, schema_default_value
         )
 
         return mapped_value
+
+    @staticmethod
+    def _extract_address_name(address: dict[str, Any]) -> str:
+        for key in ("name", "addressName", "label"):
+            val = address.get(key)
+            if isinstance(val, str) and val.strip():
+                return val.strip()
+        return ""
+
+    @staticmethod
+    def _addresses_from_config_value(raw_value: Any) -> list[dict[str, Any]]:
+        value = raw_value
+        if isinstance(raw_value, str):
+            try:
+                value = json.loads(raw_value)
+            except json.JSONDecodeError:
+                return []
+
+        if isinstance(value, dict):
+            if isinstance(value.get("addresses"), list):
+                return [a for a in value["addresses"] if isinstance(a, dict)]
+            return [value] if value else []
+        if isinstance(value, list):
+            return [a for a in value if isinstance(a, dict)]
+        return []
+
+    def _load_order_addresses_by_name(self) -> dict[str, str]:
+        entries = list(
+            self.folio_client.folio_get_all(
+                "/configurations/entries",
+                "configs",
+                self.TENANT_ADDRESSES_QUERY,
+                1000,
+            )
+        )
+        addresses_by_name: dict[str, str] = {}
+        for entry in entries:
+            entry_id = entry.get("id", "")
+            if not isinstance(entry_id, str) or not entry_id.strip():
+                continue
+            entry_id = entry_id.strip()
+            addresses = self._addresses_from_config_value(entry.get("value"))
+            for address in addresses:
+                address_name = self._extract_address_name(address)
+                if address_name:
+                    addresses_by_name[address_name.lower()] = entry_id
+
+        if addresses_by_name:
+            logger.info(
+                "Loaded %s order addresses from tenant settings",
+                len(addresses_by_name),
+            )
+        else:
+            logger.warning(
+                "No order addresses found in tenant settings (%s)",
+                self.TENANT_ADDRESSES_QUERY,
+            )
+        return addresses_by_name
+
+    def _resolve_order_address_id(self, value: str, folio_prop_name: str, index_or_id: str) -> str:
+        if not value:
+            return value
+        if self.is_uuid(value):
+            return value
+
+        resolved = self._order_addresses_by_name.get(value.lower().strip())
+        if resolved:
+            self.migration_report.add("OrderAddressMapping", f"{value} -> {resolved}")
+            return resolved
+
+        raise TransformationRecordFailedError(
+            index_or_id,
+            (f"Order address name '{value}' not found in tenant settings for {folio_prop_name}"),
+            f"Available addresses: {', '.join(sorted(self._order_addresses_by_name.keys()))}",
+        )
+
+    def _validate_hardcoded_order_address_values(self) -> None:
+        invalid_values: list[str] = []
+
+        for entry in self.record_map.get("data", []):
+            folio_field = entry.get("folio_field", "")
+            if folio_field not in {"billTo", "shipTo"}:
+                continue
+
+            for value_key in ("value", "fallback_value"):
+                mapped_value = entry.get(value_key)
+                if not mapped_value:
+                    continue
+                if self.is_uuid(mapped_value):
+                    continue
+                if mapped_value.lower().strip() not in self._order_addresses_by_name:
+                    invalid_values.append(f"- {folio_field} ({value_key}): '{mapped_value}'")
+
+        if invalid_values:
+            available = ", ".join(sorted(self._order_addresses_by_name.keys()))
+            raise TransformationProcessError(
+                "",
+                "Invalid order address values found in field mapping",
+                "\n".join(
+                    [
+                        *invalid_values,
+                        f"Available addresses: {available}",
+                    ]
+                ),
+            )
 
     @staticmethod
     def get_latest_acq_schemas_from_github(owner, repo, module, object, release_tag=None):

--- a/tests/test_infrastructure/mocked_classes.py
+++ b/tests/test_infrastructure/mocked_classes.py
@@ -146,6 +146,59 @@ def folio_get_all_mocked(ref_data_path, array_name, query="", limit=10):  # noqa
     ):
         yield from []
 
+    elif (
+        ref_data_path == "/configurations/entries"
+        and query == '?query=(module=="TENANT" and configName=="tenant.addresses")'
+    ):
+        yield from [
+            {
+                "id": "70d6f0a4-19ac-4f37-b568-4f7af7af767a",
+                "module": "TENANT",
+                "configName": "tenant.addresses",
+                "code": "ADDRESS_1779995459792",
+                "enabled": True,
+                "value": json.dumps(
+                    {
+                        "name": "Main Billing Address",
+                        "address": (
+                            "Library Building\n"
+                            "123 University Ave\n"
+                            "City, ST 00000"
+                        ),
+                    }
+                ),
+                "metadata": {
+                    "createdDate": "2026-05-28T19:10:59.990+00:00",
+                    "createdByUserId": "34d21e0a-3991-42f3-b6bf-54206c7c7783",
+                    "updatedDate": "2026-05-28T19:10:59.990+00:00",
+                    "updatedByUserId": "34d21e0a-3991-42f3-b6bf-54206c7c7783",
+                },
+            },
+            {
+                "id": "1b1f66b5-feb5-49af-ae88-f78656ec622f",
+                "module": "TENANT",
+                "configName": "tenant.addresses",
+                "code": "ADDRESS_1779995459793",
+                "enabled": True,
+                "value": json.dumps(
+                    {
+                        "name": "Main Shipping Address",
+                        "address": (
+                            "Shipping Facility\n"
+                            "456 Campus Way\n"
+                            "City, ST 00001"
+                        ),
+                    }
+                ),
+                "metadata": {
+                    "createdDate": "2026-05-28T19:10:59.990+00:00",
+                    "createdByUserId": "34d21e0a-3991-42f3-b6bf-54206c7c7783",
+                    "updatedDate": "2026-05-28T19:10:59.990+00:00",
+                    "updatedByUserId": "34d21e0a-3991-42f3-b6bf-54206c7c7783",
+                },
+            }
+        ]
+
     elif ref_data_path == "/organizations-storage/organizations":
         yield from [
             {"id": "837d04b6-d81c-4c49-9efd-2f62515999b3", "code": "GOBI"},

--- a/tests/test_orders_mapper.py
+++ b/tests/test_orders_mapper.py
@@ -556,6 +556,103 @@ def test_composite_order_mapping_with_custom_fields(mapper):
     assert mapped_order[pol_key][0]["customFields"]["lineTag"] == "rush"
 
 
+def test_composite_order_mapping_with_named_billto_shipto_addresses(mapper):
+    custom_map = deepcopy(mapper.record_map)
+    custom_map["data"].extend(
+        [
+            {
+                "folio_field": "billTo",
+                "legacy_field": "bill_to",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "shipTo",
+                "legacy_field": "ship_to",
+                "value": "",
+                "description": "",
+            },
+        ]
+    )
+
+    custom_mapper = CompositeOrderMapper(
+        mapper.folio_client,
+        mapper.library_configuration,
+        mapper.task_configuration,
+        custom_map,
+        mapper.organizations_id_map,
+        mapper.instance_id_map,
+        mapper.acquisitions_methods_mapping.map,
+        "",
+        "",
+        "",
+        mapper.location_mapping.map,
+        "",
+        "",
+    )
+
+    data = {
+        "order_number": "o126",
+        "vendor": "EBSCO",
+        "type": "One-Time",
+        "TITLE": "Address mapping",
+        "bibnumber": "1",
+        "acqmethod": "p",
+        "location": "order",
+        "copies": "1",
+        "bill_to": "Main Billing Address",
+        "ship_to": "Main Shipping Address",
+    }
+    mapped_order, _ = custom_mapper.do_map(data, data["order_number"], FOLIONamespaces.orders)
+    mapped_order = custom_mapper.perform_additional_mapping(data["order_number"], mapped_order)
+
+    assert mapped_order["billTo"] == "70d6f0a4-19ac-4f37-b568-4f7af7af767a"
+    assert mapped_order["shipTo"] == "1b1f66b5-feb5-49af-ae88-f78656ec622f"
+
+
+def test_composite_order_mapping_with_unknown_billto_address_fails(mapper):
+    custom_map = deepcopy(mapper.record_map)
+    custom_map["data"].append(
+        {
+            "folio_field": "billTo",
+            "legacy_field": "bill_to",
+            "value": "",
+            "description": "",
+        }
+    )
+
+    custom_mapper = CompositeOrderMapper(
+        mapper.folio_client,
+        mapper.library_configuration,
+        mapper.task_configuration,
+        custom_map,
+        mapper.organizations_id_map,
+        mapper.instance_id_map,
+        mapper.acquisitions_methods_mapping.map,
+        "",
+        "",
+        "",
+        mapper.location_mapping.map,
+        "",
+        "",
+    )
+
+    data = {
+        "order_number": "o127",
+        "vendor": "EBSCO",
+        "type": "One-Time",
+        "TITLE": "Unknown address mapping",
+        "bibnumber": "1",
+        "acqmethod": "p",
+        "location": "order",
+        "copies": "1",
+        "bill_to": "Unknown Billing Address",
+    }
+
+    with pytest.raises(TransformationRecordFailedError):
+        custom_mapper.do_map(data, data["order_number"], FOLIONamespaces.orders)
+
+
 def test_perform_additional_mapping_get_org_from_folio(mapper):
     pol_key = mapper.po_lines_key
     folio_po = {

--- a/tests/test_orders_mapper.py
+++ b/tests/test_orders_mapper.py
@@ -4,7 +4,10 @@ from copy import deepcopy
 import pytest
 from folio_uuid.folio_namespaces import FOLIONamespaces
 
-from folio_migration_tools.custom_exceptions import TransformationRecordFailedError
+from folio_migration_tools.custom_exceptions import (
+    TransformationProcessError,
+    TransformationRecordFailedError,
+)
 from folio_migration_tools.library_configuration import (
     FileDefinition,
     FolioRelease,
@@ -651,6 +654,82 @@ def test_composite_order_mapping_with_unknown_billto_address_fails(mapper):
 
     with pytest.raises(TransformationRecordFailedError):
         custom_mapper.do_map(data, data["order_number"], FOLIONamespaces.orders)
+
+
+def test_order_address_prevalidation_rejects_unknown_hardcoded_uuid(mapper):
+    custom_map = deepcopy(mapper.record_map)
+    custom_map["data"].append(
+        {
+            "folio_field": "billTo",
+            "legacy_field": "",
+            "value": "99999999-9999-9999-9999-999999999999",
+            "description": "",
+        }
+    )
+
+    with pytest.raises(TransformationProcessError) as exc_info:
+        CompositeOrderMapper(
+            mapper.folio_client,
+            mapper.library_configuration,
+            mapper.task_configuration,
+            custom_map,
+            mapper.organizations_id_map,
+            mapper.instance_id_map,
+            mapper.acquisitions_methods_mapping.map,
+            "",
+            "",
+            "",
+            mapper.location_mapping.map,
+            "",
+            "",
+        )
+
+    assert exc_info.value.message == "Invalid order address values found in field mapping:"
+    assert "UUID not found in tenant settings" in str(exc_info.value.data_value)
+    assert "99999999-9999-9999-9999-999999999999" in str(exc_info.value.data_value)
+
+
+def test_order_address_prevalidation_accepts_known_hardcoded_uuid(mapper):
+    custom_map = deepcopy(mapper.record_map)
+    custom_map["data"].append(
+        {
+            "folio_field": "billTo",
+            "legacy_field": "",
+            "value": "70d6f0a4-19ac-4f37-b568-4f7af7af767a",
+            "description": "",
+        }
+    )
+
+    custom_mapper = CompositeOrderMapper(
+        mapper.folio_client,
+        mapper.library_configuration,
+        mapper.task_configuration,
+        custom_map,
+        mapper.organizations_id_map,
+        mapper.instance_id_map,
+        mapper.acquisitions_methods_mapping.map,
+        "",
+        "",
+        "",
+        mapper.location_mapping.map,
+        "",
+        "",
+    )
+
+    data = {
+        "order_number": "o128",
+        "vendor": "EBSCO",
+        "type": "One-Time",
+        "TITLE": "Hardcoded address uuid",
+        "bibnumber": "1",
+        "acqmethod": "p",
+        "location": "order",
+        "copies": "1",
+    }
+
+    mapped_order, _ = custom_mapper.do_map(data, data["order_number"], FOLIONamespaces.orders)
+
+    assert mapped_order["billTo"] == "70d6f0a4-19ac-4f37-b568-4f7af7af767a"
 
 
 def test_perform_additional_mapping_get_org_from_folio(mapper):


### PR DESCRIPTION
## Purpose
Add support for resolving order billTo and shipTo values by tenant address name so Orders mappings can use human-readable address names instead of requiring hardcoded UUIDs. This also validates hardcoded address mappings early so misconfigured mapping files fail at startup rather than partway through a run.

## Changes Made in this PR
Implemented Orders-specific address resolution in the composite order mapper by loading tenant.addresses configuration entries from FOLIO, indexing them by normalized name, and mapping billTo and shipTo values to the parent configuration entry id.

Added two validation paths for this behavior:
- hardcoded value and fallback_value entries for billTo and shipTo are validated during mapper initialization and raise a process-level error if invalid
- source-data values for billTo and shipTo are resolved at record-mapping time and fail the record with a data issue if the name is unknown

Added UUID prevalidation for hardcoded order address mappings, mirroring the note-type validation pattern:
- hardcoded UUIDs in value and fallback_value must exist in tenant tenant.addresses entry IDs
- unknown UUIDs are reported in startup prevalidation with field/value context
- both UUID and name failures are aggregated before raising TransformationProcessError

Aligned config parsing to observed tenant.addresses API shape:
- one address object in entry value
- UUID at the parent entry id

Updated tests and mocked FOLIO configuration responses to cover:
- successful named billTo and shipTo resolution
- unresolved address-name record failure
- startup rejection of unknown hardcoded UUIDs
- acceptance of known hardcoded UUIDs

Updated documentation to keep generic mapping guidance separate from Orders-specific behavior, including:
- Orders task documentation for billTo and shipTo name-based mapping
- Orders-specific validation and error-reporting details
- UUID prevalidation behavior for hardcoded values
- cross-references from shared mapping and migration report documentation

Also bumped the package version to 1.12.7.

## Code Review Specifics
Please focus review on the Orders address lookup and prevalidation behavior, especially:
- use of parent configurations/entries.id as the authoritative address UUID
- startup validation parity with note-type prevalidation semantics

## Task Checklist
- [ ] Ran nox -rs safety.
- [ ] Ran pre-commit run --all-files
- [x] Tests cover new or modified code.
- [ ] Ran test suite: nox -rs tests
- [ ] Code runs and outputs default usage info: cd src; poetry run python3 -m folio_migration_tools -h
- [x] Documentation updated

## Warning Checklist
- [ ] New dependencies added
- [ ] Includes breaking changes

## How to Verify
1. Ensure required environment variables are loaded, for example with source .env.
2. Run uv run pytest test_orders_mapper.py -q.
3. Confirm the suite passes, including:
- named billTo and shipTo mapping
- unknown address-name failure
- unknown hardcoded UUID prevalidation failure
- known hardcoded UUID acceptance
4. Review docs for Orders mapping and validation/error-reporting updates.

## Open Questions
- [ ] Should this tenant-settings-backed name/UUID prevalidation pattern be generalized for other record types if similar config-backed fields are added later?

## Learn Anything Cool?
FOLIO tenant address configuration exposes the user-facing address name inside the JSON string value, while the UUID used by Orders is the parent configurations/entries record id; robust mapping has to read both layers.