### PR TITLE
Maps to ref data UUIDs should be based on whitespace normalized forms

### DIFF
--- a/docs/source/reference_data_mapping.md
+++ b/docs/source/reference_data_mapping.md
@@ -93,6 +93,7 @@ Before comparison, values are normalized by:
 - Removing ASCII control separators `\x1c`-`\x1f`
 - Removing zero-width space (`\u200B`)
 - Removing byte-order mark (`\uFEFF`)
+- Removing quote characters (ASCII double quote and common Unicode "smart quotes")
 
 This means the following are treated as equivalent when matching or validating:
 
@@ -100,6 +101,7 @@ This means the following are treated as equivalent when matching or validating:
 - `main library`
 - `Main\x1d  Library`
 - `M\u200Bain\uFEFF Library`
+- `"Main" \u201CLibrary\u201D`
 
 ### Where This Applies
 

--- a/docs/source/reference_data_mapping.md
+++ b/docs/source/reference_data_mapping.md
@@ -79,8 +79,41 @@ The FOLIO column name depends on the type of reference data being mapped:
 | Service Points | `folio_name` | Service point **name** |
 
 ```{important}
-The FOLIO column value must exactly match the value in your FOLIO tenant. Values are case-sensitive.
+The FOLIO column value must resolve to a value in your FOLIO tenant after normalization (see "Normalization Rules for Matching").
 ```
+
+## Normalization Rules for Matching
+
+Reference data matching and pre-validation use the same normalization strategy so that values are validated the same way they are matched at runtime.
+
+Before comparison, values are normalized by:
+
+- Lowercasing text
+- Removing all Unicode whitespace (`\s`)
+- Removing ASCII control separators `\x1c`-`\x1f`
+- Removing zero-width space (`\u200B`)
+- Removing byte-order mark (`\uFEFF`)
+
+This means the following are treated as equivalent when matching or validating:
+
+- `Main Library`
+- `main library`
+- `Main\x1d  Library`
+- `M\u200Bain\uFEFF Library`
+
+### Where This Applies
+
+Normalization is applied in these paths:
+
+- Reference data map row matching (including hybrid wildcard matching)
+- FOLIO value lookup when resolving mapped values to UUIDs
+- Pre-validation checks that confirm mapped FOLIO values exist
+- Note type name resolution and hardcoded note type pre-validation
+- Order bill-to / ship-to name resolution and hardcoded pre-validation
+
+### Wildcards
+
+Wildcard matching still uses `*`. Since matching values are normalized first, wildcard values with extra whitespace (for example `* `) are treated as `*`.
 
 ## Multi-Column Mapping
 

--- a/src/folio_migration_tools/circulation_helper.py
+++ b/src/folio_migration_tools/circulation_helper.py
@@ -19,8 +19,8 @@ from folioclient import (
     FolioClient,
     FolioClientError,
     FolioConnectionError,
-    FolioValidationError,
     FolioInternalServerError,
+    FolioValidationError,
 )
 
 from folio_migration_tools.helper import Helper

--- a/src/folio_migration_tools/mapping_file_transformation/holdings_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/holdings_mapper.py
@@ -28,6 +28,7 @@ from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
     RefDataMapping,
 )
 from folio_migration_tools.task_configuration import AbstractTaskConfiguration
+from folio_migration_tools.utils import normalize_for_compare
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +99,7 @@ class HoldingsMapper(MappingFileMapperBase):
             )
         self.holdings_sources = self.get_holdings_sources()
         self._holdings_note_types: dict = {
-            nt["name"].lower(): nt["id"]
+            normalize_for_compare(nt["name"]): nt["id"]
             for nt in self.folio_client.folio_get_all(
                 "/holdings-note-types", "holdingsNoteTypes", "", 1000
             )

--- a/src/folio_migration_tools/mapping_file_transformation/item_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/item_mapper.py
@@ -32,6 +32,7 @@ from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
     RefDataMapping,
 )
 from folio_migration_tools.task_configuration import AbstractTaskConfiguration
+from folio_migration_tools.utils import normalize_for_compare
 
 logger = logging.getLogger(__name__)
 
@@ -153,7 +154,7 @@ class ItemMapper(MappingFileMapperBase):
             "LocationMapping",
         )
         self._item_note_types: dict = {
-            nt["name"].lower(): nt["id"]
+            normalize_for_compare(nt["name"]): nt["id"]
             for nt in self.folio_client.folio_get_all(
                 "/item-note-types", "itemNoteTypes", "", 1000
             )

--- a/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
+++ b/src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
@@ -30,6 +30,7 @@ from folio_migration_tools.library_configuration import LibraryConfiguration
 from folio_migration_tools.mapper_base import MapperBase
 from folio_migration_tools.migration_report import MigrationReport
 from folio_migration_tools.task_configuration import AbstractTaskConfiguration
+from folio_migration_tools.utils import normalize_for_compare
 
 logger = logging.getLogger(__name__)
 
@@ -935,11 +936,12 @@ class MappingFileMapperBase(MapperBase):
 
     def get_ref_data_tuple(self, ref_data, ref_name, key_value, key_type):
         dict_key = f"{ref_name}{key_type}"
-        if ref_object := self.ref_data_dicts.get(dict_key, {}).get(key_value.lower().strip(), ()):
+        normalized_key = normalize_for_compare(key_value)
+        if ref_object := self.ref_data_dicts.get(dict_key, {}).get(normalized_key, ()):
             return ref_object
-        d = {r[key_type].lower(): (r["id"], r["name"]) for r in ref_data}
+        d = {normalize_for_compare(r[key_type]): (r["id"], r["name"]) for r in ref_data}
         self.ref_data_dicts[dict_key] = d
-        return self.ref_data_dicts.get(dict_key, {}).get(key_value.lower().strip(), ())
+        return self.ref_data_dicts.get(dict_key, {}).get(normalized_key, ())
 
     def validate_enums(
         self,
@@ -1036,7 +1038,7 @@ class MappingFileMapperBase(MapperBase):
                 index_or_id,
                 folio_prop_name,
             )
-        resolved = note_types_by_name.get(value.lower().strip())
+        resolved = note_types_by_name.get(normalize_for_compare(value))
         if resolved:
             self.migration_report.add("MappedNoteTypes", f"{value} -> {resolved}")
             return resolved
@@ -1152,7 +1154,7 @@ class MappingFileMapperBase(MapperBase):
                 )
         # Name validation
         else:
-            if value.lower() not in note_types_by_name:
+            if normalize_for_compare(value) not in note_types_by_name:
                 return (
                     f"  - '{value}' (in field: {folio_field}, "
                     f"{field_type}) - name not found in FOLIO"

--- a/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
+++ b/src/folio_migration_tools/mapping_file_transformation/order_mapper.py
@@ -33,6 +33,7 @@ from folio_migration_tools.mapping_file_transformation.notes_mapper import Notes
 from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
     RefDataMapping,
 )
+from folio_migration_tools.utils import normalize_for_compare
 
 logger = logging.getLogger(__name__)
 
@@ -334,7 +335,7 @@ class CompositeOrderMapper(MappingFileMapperBase):
                 continue
             address_name = self._extract_address_name(address)
             if address_name:
-                addresses_by_name[address_name.lower()] = entry_id
+                addresses_by_name[normalize_for_compare(address_name)] = entry_id
 
         if addresses_by_name:
             logger.info(
@@ -354,7 +355,7 @@ class CompositeOrderMapper(MappingFileMapperBase):
         if self.is_uuid(value):
             return value
 
-        resolved = self._order_addresses_by_name.get(value.lower().strip())
+        resolved = self._order_addresses_by_name.get(normalize_for_compare(value))
         if resolved:
             self.migration_report.add("OrderAddressMapping", f"{value} -> {resolved}")
             return resolved
@@ -386,7 +387,7 @@ class CompositeOrderMapper(MappingFileMapperBase):
                 )
             return None
 
-        if value.lower() not in address_names_by_name:
+        if normalize_for_compare(value) not in address_names_by_name:
             return (
                 f"  - '{value}' (in field: {folio_field}, {field_type}) "
                 "- name not found in tenant settings"

--- a/src/folio_migration_tools/mapping_file_transformation/ref_data_mapping.py
+++ b/src/folio_migration_tools/mapping_file_transformation/ref_data_mapping.py
@@ -12,6 +12,7 @@ import sys
 from folioclient import FolioClient
 
 from folio_migration_tools.custom_exceptions import TransformationProcessError
+from folio_migration_tools.utils import normalize_for_compare
 
 logger = logging.getLogger(__name__)
 
@@ -54,12 +55,14 @@ class RefDataMapping(object):
         logger.info("%s reference data mapping. Done init", self.name)
 
     def get_ref_data_tuple(self, key_value):
-        if ref_object := self.cached_dict.get(key_value.lower().strip(), ()):
+        normalized_key = normalize_for_compare(key_value)
+        if ref_object := self.cached_dict.get(normalized_key, ()):
             return ref_object
         self.cached_dict = {
-            r[self.key_type].lower(): (r["id"], r[self.key_type]) for r in self.ref_data
+            normalize_for_compare(r[self.key_type]): (r["id"], r[self.key_type])
+            for r in self.ref_data
         }
-        return self.cached_dict.get(key_value.lower().strip(), ())
+        return self.cached_dict.get(normalized_key, ())
 
     def setup_mappings(self):
         if not self.map:
@@ -118,20 +121,25 @@ class RefDataMapping(object):
         )
 
     def get_hybrid_mapping(self, legacy_object):
-        obj_key = "_".join(legacy_object[k].strip() for k in self.mapped_legacy_keys)
+        obj_key = "_".join(
+            normalize_for_compare(legacy_object[k]) for k in self.mapped_legacy_keys
+        )
         if obj_key in self.cache:
             return self.cache[obj_key]
         highest_match = None
         highest_match_number = 0
 
-        prepped_props = {k: legacy_object[k].strip() for k in self.mapped_legacy_keys}
+        prepped_props = {
+            k: normalize_for_compare(legacy_object[k]) for k in self.mapped_legacy_keys
+        }
         for mapping in self.hybrid_mappings:
             mismatch = 0
             match_numbers = []
             for k in self.mapped_legacy_keys:
-                if mapping[k] == prepped_props[k]:
+                normalized_map_value = normalize_for_compare(mapping[k])
+                if normalized_map_value == prepped_props[k]:
                     match_numbers.append(10)
-                elif mapping[k] == "*":
+                elif normalized_map_value == "*":
                     match_numbers.append(1)
                 else:
                     mismatch += 1
@@ -144,23 +152,38 @@ class RefDataMapping(object):
         return highest_match
 
     def get_ref_data_mapping(self, legacy_object):
-        obj_key = "_".join(legacy_object[k].strip() for k in self.mapped_legacy_keys)
+        obj_key = "_".join(
+            normalize_for_compare(legacy_object[k]) for k in self.mapped_legacy_keys
+        )
         if obj_key in self.cache:
             return self.cache[obj_key]
-        prepped_props = {k: legacy_object[k].strip() for k in self.mapped_legacy_keys}
+        prepped_props = {
+            k: normalize_for_compare(legacy_object[k]) for k in self.mapped_legacy_keys
+        }
         for mapping in self.regular_mappings:
-            match_number = sum(prepped_props[k] == mapping[k] for k in self.mapped_legacy_keys)
+            match_number = sum(
+                prepped_props[k] == normalize_for_compare(mapping[k])
+                for k in self.mapped_legacy_keys
+            )
             if match_number == len(self.mapped_legacy_keys):
                 self.cache[obj_key] = mapping
                 return mapping
         return None
 
     def is_hybrid_default_mapping(self, mapping):
-        legacy_values = [value for key, value in mapping.items() if key in self.mapped_legacy_keys]
+        legacy_values = [
+            normalize_for_compare(value)
+            for key, value in mapping.items()
+            if key in self.mapped_legacy_keys
+        ]
         return "*" in legacy_values and not self.is_default_mapping(mapping)
 
     def is_default_mapping(self, mapping):
-        legacy_values = [value for key, value in mapping.items() if key in self.mapped_legacy_keys]
+        legacy_values = [
+            normalize_for_compare(value)
+            for key, value in mapping.items()
+            if key in self.mapped_legacy_keys
+        ]
         return all(f == "*" for f in legacy_values)
 
     def pre_validate_map(self):
@@ -168,8 +191,10 @@ class RefDataMapping(object):
             raise TransformationProcessError(
                 "", f"Column folio_{self.key_type} missing from {self.name} map file"
             )
-        folio_values_from_map = [f[f"folio_{self.key_type}"] for f in self.map]
-        folio_values_from_folio = [r[self.key_type] for r in self.ref_data]
+        folio_values_from_map = [
+            normalize_for_compare(f[f"folio_{self.key_type}"]) for f in self.map
+        ]
+        folio_values_from_folio = [normalize_for_compare(r[self.key_type]) for r in self.ref_data]
         folio_values_not_in_map = list(
             {f for f in folio_values_from_folio if f not in folio_values_from_map}
         )

--- a/src/folio_migration_tools/migration_tasks/loans_migrator.py
+++ b/src/folio_migration_tools/migration_tasks/loans_migrator.py
@@ -12,8 +12,8 @@ import logging
 import sys
 import time
 import traceback
-from datetime import datetime, timedelta
 from collections.abc import AsyncGenerator
+from datetime import datetime, timedelta
 from typing import Annotated, List, Literal
 from urllib.error import HTTPError
 from zoneinfo import ZoneInfo

--- a/src/folio_migration_tools/migration_tasks/requests_migrator.py
+++ b/src/folio_migration_tools/migration_tasks/requests_migrator.py
@@ -11,8 +11,8 @@ import logging
 import sys
 import time
 from collections.abc import AsyncGenerator
-from typing import Annotated, Optional
 from datetime import datetime, timedelta
+from typing import Annotated, Optional
 from zoneinfo import ZoneInfo
 
 import folioclient

--- a/src/folio_migration_tools/utils.py
+++ b/src/folio_migration_tools/utils.py
@@ -7,4 +7,8 @@ def normalize_for_compare(value):
     """Normalize values for case/whitespace-insensitive comparisons."""
     if value is None:
         return ""
-    return re.sub(r"[\s\x1c-\x1f\u200B\uFEFF]+", "", str(value)).lower()
+    return re.sub(
+        r'[\s\x1c-\x1f\u200B\uFEFF"\u2018\u2019\u201A\u201B\u201C\u201D\u201E\u201F]+',
+        "",
+        str(value),
+    ).lower()

--- a/src/folio_migration_tools/utils.py
+++ b/src/folio_migration_tools/utils.py
@@ -7,4 +7,4 @@ def normalize_for_compare(value):
     """Normalize values for case/whitespace-insensitive comparisons."""
     if value is None:
         return ""
-    return re.sub(r"[\s\x1c-\x1f]+", "", str(value)).lower()
+    return re.sub(r"[\s\x1c-\x1f\u200B\uFEFF]+", "", str(value)).lower()

--- a/src/folio_migration_tools/utils.py
+++ b/src/folio_migration_tools/utils.py
@@ -1,0 +1,10 @@
+"""Generic utility helpers shared across folio_migration_tools modules."""
+
+import re
+
+
+def normalize_for_compare(value):
+    """Normalize values for case/whitespace-insensitive comparisons."""
+    if value is None:
+        return ""
+    return re.sub(r"[\s\x1c-\x1f]+", "", str(value)).lower()

--- a/tests/test_mapping_file_mapper_base.py
+++ b/tests/test_mapping_file_mapper_base.py
@@ -6432,6 +6432,33 @@ def test_validate_hardcoded_note_type_values_valid_names(mocked_folio_client, mo
     mapper._validate_hardcoded_note_type_values(note_types_by_name, ".itemNoteTypeId")
 
 
+def test_validate_hardcoded_note_type_values_normalized_name_match(
+    mocked_folio_client, mocked_file_mapper
+):
+    """Validation accepts names that differ only by case/whitespace/control separators."""
+    schema = mocked_file_mapper.schema
+    note_types_by_name = {
+        "staffnote": "11111111-1111-1111-1111-111111111111",
+    }
+    the_map = {
+        "data": [
+            {"folio_field": "legacyIdentifier", "legacy_field": "id", "value": "", "fallback_value": "", "description": ""},
+            {"folio_field": "notes[0].itemNoteTypeId", "legacy_field": "", "value": "Sta ff\x1d Note", "fallback_value": "", "description": ""},
+        ]
+    }
+    mapper = MappingFileMapperBase(
+        mocked_folio_client,
+        schema,
+        the_map,
+        None,
+        FOLIONamespaces.items,
+        mocked_classes.get_mocked_library_config(),
+        mocked_file_mapper.task_configuration,
+    )
+
+    mapper._validate_hardcoded_note_type_values(note_types_by_name, ".itemNoteTypeId")
+
+
 def test_validate_hardcoded_note_type_values_valid_uuids(mocked_folio_client, mocked_file_mapper):
     """Test validation passes when hardcoded values are valid UUIDs."""
     schema = mocked_file_mapper.schema

--- a/tests/test_orders_mapper.py
+++ b/tests/test_orders_mapper.py
@@ -613,6 +613,60 @@ def test_composite_order_mapping_with_named_billto_shipto_addresses(mapper):
     assert mapped_order["shipTo"] == "1b1f66b5-feb5-49af-ae88-f78656ec622f"
 
 
+def test_composite_order_mapping_with_normalized_named_addresses(mapper):
+    custom_map = deepcopy(mapper.record_map)
+    custom_map["data"].extend(
+        [
+            {
+                "folio_field": "billTo",
+                "legacy_field": "bill_to",
+                "value": "",
+                "description": "",
+            },
+            {
+                "folio_field": "shipTo",
+                "legacy_field": "ship_to",
+                "value": "",
+                "description": "",
+            },
+        ]
+    )
+
+    custom_mapper = CompositeOrderMapper(
+        mapper.folio_client,
+        mapper.library_configuration,
+        mapper.task_configuration,
+        custom_map,
+        mapper.organizations_id_map,
+        mapper.instance_id_map,
+        mapper.acquisitions_methods_mapping.map,
+        "",
+        "",
+        "",
+        mapper.location_mapping.map,
+        "",
+        "",
+    )
+
+    data = {
+        "order_number": "o126b",
+        "vendor": "EBSCO",
+        "type": "One-Time",
+        "TITLE": "Address mapping normalized",
+        "bibnumber": "1",
+        "acqmethod": "p",
+        "location": "order",
+        "copies": "1",
+        "bill_to": "Main  Billing\x1dAddress",
+        "ship_to": "Main\tShipping Address",
+    }
+    mapped_order, _ = custom_mapper.do_map(data, data["order_number"], FOLIONamespaces.orders)
+    mapped_order = custom_mapper.perform_additional_mapping(data["order_number"], mapped_order)
+
+    assert mapped_order["billTo"] == "70d6f0a4-19ac-4f37-b568-4f7af7af767a"
+    assert mapped_order["shipTo"] == "1b1f66b5-feb5-49af-ae88-f78656ec622f"
+
+
 def test_composite_order_mapping_with_unknown_billto_address_fails(mapper):
     custom_map = deepcopy(mapper.record_map)
     custom_map["data"].append(
@@ -721,6 +775,49 @@ def test_order_address_prevalidation_accepts_known_hardcoded_uuid(mapper):
         "vendor": "EBSCO",
         "type": "One-Time",
         "TITLE": "Hardcoded address uuid",
+        "bibnumber": "1",
+        "acqmethod": "p",
+        "location": "order",
+        "copies": "1",
+    }
+
+    mapped_order, _ = custom_mapper.do_map(data, data["order_number"], FOLIONamespaces.orders)
+
+    assert mapped_order["billTo"] == "70d6f0a4-19ac-4f37-b568-4f7af7af767a"
+
+
+def test_order_address_prevalidation_accepts_normalized_hardcoded_name(mapper):
+    custom_map = deepcopy(mapper.record_map)
+    custom_map["data"].append(
+        {
+            "folio_field": "billTo",
+            "legacy_field": "",
+            "value": "Main\x1d Billing  Address",
+            "description": "",
+        }
+    )
+
+    custom_mapper = CompositeOrderMapper(
+        mapper.folio_client,
+        mapper.library_configuration,
+        mapper.task_configuration,
+        custom_map,
+        mapper.organizations_id_map,
+        mapper.instance_id_map,
+        mapper.acquisitions_methods_mapping.map,
+        "",
+        "",
+        "",
+        mapper.location_mapping.map,
+        "",
+        "",
+    )
+
+    data = {
+        "order_number": "o128b",
+        "vendor": "EBSCO",
+        "type": "One-Time",
+        "TITLE": "Hardcoded address normalized name",
         "bibnumber": "1",
         "acqmethod": "p",
         "location": "order",

--- a/tests/test_ref_data_mappings.py
+++ b/tests/test_ref_data_mappings.py
@@ -165,6 +165,17 @@ def test_get_ref_data_tuple_strips_zero_width_and_bom():
     assert res == ("uuid-1", "Main Library")
 
 
+def test_get_ref_data_tuple_strips_ascii_and_smart_quotes():
+    mock = Mock(spec=RefDataMapping)
+    mock.cached_dict = {}
+    mock.key_type = "name"
+    mock.ref_data = [{"id": "uuid-1", "name": "Main Library"}]
+
+    res = RefDataMapping.get_ref_data_tuple(mock, '"Main" \u201CLibrary\u201D')
+
+    assert res == ("uuid-1", "Main Library")
+
+
 def test_pre_validate_map_allows_normalized_folio_value_matches():
     mock = Mock(spec=RefDataMapping)
     mock.key_type = "name"

--- a/tests/test_ref_data_mappings.py
+++ b/tests/test_ref_data_mappings.py
@@ -108,7 +108,7 @@ def test_get_hybrid_mapping3():
     mock.cache = {}
     mock.mapped_legacy_keys = ["location", "loan_type", "material_type"]
     res = RefDataMapping.get_hybrid_mapping(mock, legacy_object)
-    assert res is None
+    assert res == mock.hybrid_mappings[0]
 
 
 def test_normal_refdata_mapping_strip():
@@ -124,6 +124,44 @@ def test_normal_refdata_mapping_strip():
     mock.mapped_legacy_keys = ["location", "loan_type", "material_type"]
     res = RefDataMapping.get_ref_data_mapping(mock, legacy_object)
     assert res == mappings[2]
+
+
+def test_normal_refdata_mapping_strips_internal_whitespace_and_group_separator():
+    mappings = [
+        {"location": "ABC", "loan_type": "lt1", "material_type": "mt2"},
+    ]
+    legacy_object = {
+        "location": "A B\x1dC",
+        "loan_type": "l t1",
+        "material_type": "m t 2",
+    }
+    mock = Mock(spec=RefDataMapping)
+    mock.regular_mappings = mappings
+    mock.cache = {}
+    mock.mapped_legacy_keys = ["location", "loan_type", "material_type"]
+    res = RefDataMapping.get_ref_data_mapping(mock, legacy_object)
+    assert res == mappings[0]
+
+
+def test_get_ref_data_tuple_uses_normalized_comparison():
+    mock = Mock(spec=RefDataMapping)
+    mock.cached_dict = {}
+    mock.key_type = "name"
+    mock.ref_data = [{"id": "uuid-1", "name": "Main Library"}]
+
+    res = RefDataMapping.get_ref_data_tuple(mock, "Main\x1d  Library")
+
+    assert res == ("uuid-1", "Main Library")
+
+
+def test_pre_validate_map_allows_normalized_folio_value_matches():
+    mock = Mock(spec=RefDataMapping)
+    mock.key_type = "name"
+    mock.name = "locations"
+    mock.map = [{"folio_name": "Main\x1dLibrary", "legacy_code": "MAIN"}]
+    mock.ref_data = [{"name": "Main Library"}]
+
+    RefDataMapping.pre_validate_map(mock)
 
 
 def test_mapping_for_multiple_fields():

--- a/tests/test_ref_data_mappings.py
+++ b/tests/test_ref_data_mappings.py
@@ -154,6 +154,17 @@ def test_get_ref_data_tuple_uses_normalized_comparison():
     assert res == ("uuid-1", "Main Library")
 
 
+def test_get_ref_data_tuple_strips_zero_width_and_bom():
+    mock = Mock(spec=RefDataMapping)
+    mock.cached_dict = {}
+    mock.key_type = "name"
+    mock.ref_data = [{"id": "uuid-1", "name": "Main Library"}]
+
+    res = RefDataMapping.get_ref_data_tuple(mock, "M\u200Bain\uFEFF Library")
+
+    assert res == ("uuid-1", "Main Library")
+
+
 def test_pre_validate_map_allows_normalized_folio_value_matches():
     mock = Mock(spec=RefDataMapping)
     mock.key_type = "name"


### PR DESCRIPTION
## Purpose
Fixes #944.

Reference-data mapping and validation could disagree when values differed only by spacing, control separators, invisible characters, or quote style. In practice, records could map successfully at runtime but still be flagged as invalid during pre-validation. This change keeps normalization behavior consistent across mapping and pre-validation paths.

## Changes Made in this PR
- Introduced shared normalization utility in src/folio_migration_tools/utils.py:
  - normalize_for_compare(value) removes whitespace, ASCII group/record separators (\x1c-\x1f), zero-width/BOM characters, normalizes case, and strips ASCII/smart quote characters used in source data.
- Updated ref-data mapping flows to use the shared normalizer:
  - src/folio_migration_tools/mapping_file_transformation/ref_data_mapping.py
  - Applies to tuple lookups, regular mapping, hybrid mapping, default/wildcard checks, and pre-validation map-vs-FOLIO checks.
- Updated mapping base validation/resolution paths to use shared normalization:
  - src/folio_migration_tools/mapping_file_transformation/mapping_file_mapper_base.py
  - Applies to generic tuple lookup plus note-type resolution and hardcoded note-type pre-validation.
- Updated consumers that build note-type/address lookup dicts:
  - src/folio_migration_tools/mapping_file_transformation/holdings_mapper.py
  - src/folio_migration_tools/mapping_file_transformation/item_mapper.py
  - src/folio_migration_tools/mapping_file_transformation/order_mapper.py
- Added/updated tests for normalized matching behavior:
  - tests/test_ref_data_mappings.py
  - tests/test_mapping_file_mapper_base.py
  - tests/test_orders_mapper.py
- Added documentation section describing normalization rules and scope:
  - docs/source/reference_data_mapping.md

## Code Review Specifics
- Please focus on whether normalization semantics are appropriate and consistently applied for:
  - ref-data matching
  - note-type name resolution and validation
  - order address name resolution and validation
- Confirm we are not over-normalizing in a way that could cause false-positive matches in your expected datasets.

## Task Checklist
- [ ] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [ ] Ran test suite: `nox -rs tests`
- [ ] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [x] Documentation updated

## Warning Checklist
- [ ] New dependencies added
- [ ] Includes breaking changes

## How to Verify
1. Check out branch feature/maps-to-ref-data-uuids-should-be-based-on-whitespace-normalized-forms-944.
2. Run targeted validation used during development:
   - source .env && uv run pytest tests/test_ref_data_mappings.py tests/test_mapping_file_mapper_base.py tests/test_orders_mapper.py tests/test_holdings_mapper.py tests/test_items_mapper.py
3. Confirm expected outcome:
   - 233 passed, 1 skipped, 0 failed
4. Spot-check behaviors:
   - Ref-data mapping matches values that differ only by case, spacing, invisible/control separators, and quote-style differences.
   - Hardcoded note type values and order address names are pre-validated consistently with runtime resolution.

## Open Questions
- [ ] Should any additional punctuation classes be normalized in this PR, or should broader punctuation normalization be handled in a follow-up with explicit ambiguity safeguards?

## Learn Anything Cool?
Normalization drift between validation and runtime mapping is a subtle source of false failures. Centralizing comparison normalization in one utility reduced behavioral drift and made tests and docs easier to keep aligned.
