### PR TITLE
Feature/allow code based service point references in loans and request transaction data map service points by code 1034

### DIFF
--- a/docs/source/tasks/loans_migrator.md
+++ b/docs/source/tasks/loans_migrator.md
@@ -35,8 +35,9 @@ This task creates real circulation transactions and **can generate thousands of 
 |-----------|------|----------|-------------|
 | `name` | string | Yes | The name of this task. |
 | `migrationTaskType` | string | Yes | Must be `"LoansMigrator"` |
-| `fallbackServicePointId` | string | Yes | UUID of service point for check-out transactions |
+| `fallbackServicePointId` | string | Yes | Service point UUID or code for check-out transactions when not specified per-loan |
 | `openLoansFiles` | array | Yes | List of loan data files with optional per-file service point |
+| `servicePointMapFileName` | string | No | Filename of a TSV mapping file for translating legacy service point codes to FOLIO codes |
 | `startingRow` | integer | No | Row number to start processing (for resuming). Default: 1 |
 | `skipBarcodePrevalidation` | boolean | No | Skip pre-validation of patron and item barcodes against FOLIO. Default: false |
 | `itemFiles` | array | No | **Deprecated.** No longer used for pre-validation. |
@@ -63,7 +64,33 @@ This task creates real circulation transactions and **can generate thousands of 
 | `proxy_patron_barcode` | Barcode of proxy borrower (if applicable) |
 | `renewal_count` | Number of times the loan has been renewed |
 | `next_item_status` | Item status to set after loan is created |
-| `service_point_id` | Override service point for this specific loan |
+| `service_point_id` | Override service point for this specific loan (UUID or code) |
+
+### Service Point Values
+
+The `service_point_id` column and `fallbackServicePointId` parameter accept either:
+
+- A **UUID** of a FOLIO service point (e.g., `a77b55e7-f9f3-40a1-83e0-241bc606a826`)
+- A **code** of a FOLIO service point (e.g., `circ-desk`)
+
+All service point values are validated against FOLIO before loan processing begins. If any value cannot be resolved, the task halts with an error.
+
+### Service Point Mapping File
+
+When `servicePointMapFileName` is provided, the task loads a TSV file from the `mapping_files` folder that maps legacy service point codes to FOLIO service point codes. This is useful when your legacy system uses different codes than FOLIO.
+
+**Format**: Tab-separated with headers `service_point_id` and `folio_code`:
+
+```text
+service_point_id	folio_code
+MAIN_CIRC	circ-desk
+BRANCH1	branch-desk
+*	circ-desk
+```
+
+- `service_point_id` — The legacy code that appears in your source data
+- `folio_code` — The corresponding FOLIO service point code
+- `*` — Required wildcard row (must be present for file validation, but is not used as a runtime fallback; unmatched codes will produce an error)
 
 ### Example Data
 
@@ -81,6 +108,14 @@ Dates should be in ISO 8601 format:
 - `2024-12-15T10:30:00-05:00` (with timezone)
 
 ## Pre-validation
+
+The task performs several validation steps before creating loans.
+
+### Service point validation
+
+All unique service point values (from source data and the fallback) are validated against FOLIO before any barcode checking occurs. Both UUIDs and codes are verified to exist. If any service point cannot be found, the task halts immediately. Service point codes are resolved to UUIDs for the circulation API.
+
+### Barcode validation
 
 By default, the task validates patron and item barcodes directly against the FOLIO tenant before attempting to create loans. This can be disabled by setting `skipBarcodePrevalidation` to `true`.
 
@@ -191,6 +226,24 @@ Files are created in `iterations/<iteration>/results/`:
     ]
 }
 ```
+
+### Using Service Point Codes with a Mapping File
+
+```json
+{
+    "name": "migrate_loans",
+    "migrationTaskType": "LoansMigrator",
+    "fallbackServicePointId": "circ-desk",
+    "servicePointMapFileName": "service_point_map.tsv",
+    "openLoansFiles": [
+        {
+            "file_name": "loans.tsv"
+        }
+    ]
+}
+```
+
+In this example, both the `fallbackServicePointId` and values in the source data's `service_point_id` column can be FOLIO service point codes. The `service_point_map.tsv` file translates legacy codes to FOLIO codes.
 
 ## Running the Task
 

--- a/docs/source/tasks/requests_migrator.md
+++ b/docs/source/tasks/requests_migrator.md
@@ -18,6 +18,7 @@ This task creates real circulation transactions. Ensure items and users have bee
 {
     "name": "migrate_requests",
     "migrationTaskType": "RequestsMigrator",
+    "fallbackServicePointId": "a77b55e7-f9f3-40a1-83e0-241bc606a826",
     "openRequestsFile": {
         "file_name": "requests.tsv"
     },
@@ -32,7 +33,9 @@ This task creates real circulation transactions. Ensure items and users have bee
 |-----------|------|----------|-------------|
 | `name` | string | Yes | The name of this task. |
 | `migrationTaskType` | string | Yes | Must be `"RequestsMigrator"` |
+| `fallbackServicePointId` | string | Yes | Service point UUID or code to use when a request has no pickup service point |
 | `openRequestsFile` | object | Yes | File definition with `file_name` for request data |
+| `servicePointMapFileName` | string | No | Filename of a TSV mapping file for translating legacy service point codes to FOLIO codes |
 | `startingRow` | integer | No | Row number to start processing. Default: 1 |
 | `skipBarcodePrevalidation` | boolean | No | Skip pre-validation of patron and item barcodes against FOLIO. Default: false |
 
@@ -54,20 +57,54 @@ This task creates real circulation transactions. Ensure items and users have bee
 
 | Column | Description |
 |--------|-------------|
-| `pickup_service_point_id` | UUID of the pickup location |
+| `pickup_servicepoint_id` | Pickup location service point (UUID or code) |
 | `expiration_date` | Request expiration date |
 | `request_level` | Item or Title level request |
 | `fulfillment_preference` | Hold Shelf or Delivery |
 
+### Service Point Values
+
+The `pickup_servicepoint_id` column and `fallbackServicePointId` parameter accept either:
+
+- A **UUID** of a FOLIO service point (e.g., `a77b55e7-f9f3-40a1-83e0-241bc606a826`)
+- A **code** of a FOLIO service point (e.g., `circ-desk`)
+
+All service point values are validated against FOLIO before barcode pre-validation begins. If any value cannot be resolved, the task halts with an error.
+
+### Service Point Mapping File
+
+When `servicePointMapFileName` is provided, the task loads a TSV file from the `mapping_files` folder that maps legacy service point codes to FOLIO service point codes.
+
+**Format**: Tab-separated with headers `service_point_id` and `folio_code`:
+
+```text
+service_point_id	folio_code
+MAIN_CIRC	circ-desk
+BRANCH1	branch-desk
+*	circ-desk
+```
+
+- `service_point_id` — The legacy code that appears in your source data
+- `folio_code` — The corresponding FOLIO service point code
+- `*` — Required wildcard row (must be present for file validation, but is not used as a runtime fallback; unmatched codes will produce an error)
+
 ### Example Data
 
 ```text
-item_barcode	patron_barcode	request_type	request_date	pickup_service_point_id
-1234567890	P001234	Hold	2024-11-01	a77b55e7-f9f3-40a1-83e0-241bc606a826
+item_barcode	patron_barcode	request_type	request_date	pickup_servicepoint_id
+1234567890	P001234	Hold	2024-11-01	circ-desk
 0987654321	P005678	Recall	2024-11-15	a77b55e7-f9f3-40a1-83e0-241bc606a826
 ```
 
 ## Pre-validation
+
+The task performs several validation steps before creating requests.
+
+### Service point validation
+
+All unique service point values (from source data and the fallback) are validated against FOLIO before any barcode checking occurs. Both UUIDs and codes are verified to exist. If any service point cannot be found, the task halts immediately. Service point codes are resolved to UUIDs for the circulation API.
+
+### Barcode validation
 
 By default, the task validates request barcodes directly against FOLIO before attempting to create requests.
 
@@ -95,6 +132,7 @@ Files are created in `iterations/<iteration>/results/`:
 {
     "name": "migrate_requests",
     "migrationTaskType": "RequestsMigrator",
+    "fallbackServicePointId": "a77b55e7-f9f3-40a1-83e0-241bc606a826",
     "openRequestsFile": {
         "file_name": "requests.tsv"
     }
@@ -107,12 +145,29 @@ Files are created in `iterations/<iteration>/results/`:
 {
     "name": "migrate_requests",
     "migrationTaskType": "RequestsMigrator",
+    "fallbackServicePointId": "a77b55e7-f9f3-40a1-83e0-241bc606a826",
     "openRequestsFile": {
         "file_name": "requests.tsv"
     },
     "skipBarcodePrevalidation": true
 }
 ```
+
+### Using Service Point Codes with a Mapping File
+
+```json
+{
+    "name": "migrate_requests",
+    "migrationTaskType": "RequestsMigrator",
+    "fallbackServicePointId": "circ-desk",
+    "servicePointMapFileName": "service_point_map.tsv",
+    "openRequestsFile": {
+        "file_name": "requests.tsv"
+    }
+}
+```
+
+In this example, both the `fallbackServicePointId` and values in the source data's `pickup_servicepoint_id` column can be FOLIO service point codes. The `service_point_map.tsv` file translates legacy codes to FOLIO codes.
 
 ## Running the Task
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "folio_migration_tools"
-version = "1.12.7"
+version = "1.12.8"
 description =  "A tool allowing you to migrate data from legacy ILS:s (Library systems) into FOLIO LSP"
 authors = [
 	{name = "Theodor Tolstoy", email = "github.teddes@tolstoy.se"},
@@ -14,7 +14,7 @@ readme = "README.md"
 keywords = ["FOLIO", "ILS", "LSP", "Library Systems", "MARC21", "Library data"]
 requires-python = ">=3.10,<4.0"
 dependencies = [
-    "folioclient>=1.0.7,<2.0.0",
+    "folioclient>=1.0.11,<2.0.0",
     "pyhumps>=3.7.3,<4.0.0",
     "defusedxml>=0.7.1,<1.0.0",
     "python-dateutil>=2.8.2,<3.0.0",

--- a/src/folio_migration_tools/migration_tasks/loans_migrator.py
+++ b/src/folio_migration_tools/migration_tasks/loans_migrator.py
@@ -14,7 +14,7 @@ import time
 import traceback
 from collections.abc import AsyncGenerator
 from datetime import datetime, timedelta
-from typing import Annotated, List, Literal
+from typing import Annotated, List, Literal, Optional
 from urllib.error import HTTPError
 from zoneinfo import ZoneInfo
 
@@ -36,6 +36,9 @@ from folio_migration_tools.library_configuration import (
 from folio_migration_tools.mapping_file_transformation.mapping_file_mapper_base import (
     MappingFileMapperBase,
 )
+from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
+    RefDataMapping,
+)
 from folio_migration_tools.migration_report import MigrationReport
 from folio_migration_tools.migration_tasks.migration_task_base import MigrationTaskBase
 from folio_migration_tools.task_configuration import AbstractTaskConfiguration
@@ -43,6 +46,7 @@ from folio_migration_tools.transaction_migration.legacy_loan import LegacyLoan
 from folio_migration_tools.transaction_migration.transaction_result import (
     TransactionResult,
 )
+from folio_migration_tools.utils import is_uuid
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +80,8 @@ class LoansMigrator(MigrationTaskBase):
             str,
             Field(
                 title="Fallback service point ID",
-                description="Identifier of the fallback service point.",
+                description="Identifier of the fallback service point (UUID or code).",
+                min_length=1,
             ),
         ]
         starting_row: Annotated[
@@ -110,6 +115,16 @@ class LoansMigrator(MigrationTaskBase):
                 ),
             ),
         ] = False
+        service_point_map_file_name: Annotated[
+            Optional[str],
+            Field(
+                title="Service point map file name",
+                description=(
+                    "Optional file name for service point mapping. Maps legacy service point "
+                    "codes to FOLIO service point codes."
+                ),
+            ),
+        ] = ""
 
     @staticmethod
     def get_object_type() -> FOLIONamespaces:
@@ -145,6 +160,9 @@ class LoansMigrator(MigrationTaskBase):
             task_configuration.fallback_service_point_id,
             self.migration_report,
         )
+        self._init_service_point_mapping(task_configuration)
+        # Pre-validate fallback service point during initialization
+        self._validate_fallback_service_point(task_configuration.fallback_service_point_id)
         logger.info("Check that SMTP is disabled before migrating loans")
         self.check_smtp_config()
         logger.info("Proceeding with loans migration")
@@ -241,6 +259,112 @@ class LoansMigrator(MigrationTaskBase):
         else:
             logger.info("SMTP connection is disabled...")
 
+    def _init_service_point_mapping(self, task_configuration: TaskConfiguration):
+        """Initialize the service point mapping from an optional TSV file.
+
+        Args:
+            task_configuration (TaskConfiguration): Task configuration with mapping file name.
+        """
+        self.service_point_mapping: RefDataMapping | None = None
+        if task_configuration.service_point_map_file_name:
+            service_point_map = self.load_ref_data_mapping_file(
+                "servicePointId",
+                self.folder_structure.mapping_files_folder
+                / task_configuration.service_point_map_file_name,
+                ["servicePointId"],
+                False,
+            )
+            if service_point_map:
+                self.service_point_mapping = RefDataMapping(
+                    self.folio_client,
+                    "/service-points",
+                    "servicepoints",
+                    service_point_map,
+                    "code",
+                    "ServicePointMapping",
+                )
+
+    def _validate_fallback_service_point(self, fallback_service_point_id: str):
+        """Validate that the fallback service point exists in FOLIO.
+
+        Args:
+            fallback_service_point_id (str): The fallback service point ID (UUID or code).
+
+        Raises:
+            SystemExit: If fallback service point is not found in FOLIO.
+        """
+        if not fallback_service_point_id or not fallback_service_point_id.strip():
+            logger.info("No fallback service point configured")
+            return
+
+        try:
+            logger.info(f"Validating fallback service point: {fallback_service_point_id}")
+
+            # Build lookup structures for both ID (UUID) and code
+            service_point_ids = {sp["id"] for sp in self.folio_client.service_points}
+            service_points_by_code = {
+                sp["code"]: sp["id"] for sp in self.folio_client.service_points if sp.get("code")
+            }
+
+            # Check if fallback exists as UUID or code
+            if (
+                fallback_service_point_id not in service_point_ids
+                and fallback_service_point_id not in service_points_by_code
+            ):
+                logger.critical(
+                    "Fallback service point '%s' does not exist in FOLIO",
+                    fallback_service_point_id,
+                )
+                logger.critical(
+                    "Task initialization failed. Please verify fallback service point."
+                )
+                sys.exit(1)
+
+            logger.info(
+                f"Successfully validated fallback service point: {fallback_service_point_id}"
+            )
+
+        except Exception as e:
+            logger.exception("Error validating fallback service point: %s", e)
+            logger.critical(
+                "Task initialization failed due to fallback service point validation error"
+            )
+            sys.exit(1)
+
+    async def pre_validate_service_points(self):
+        """Validate all service point values exist in FOLIO, then resolve codes to UUIDs."""
+        if not self.semi_valid_legacy_loans:
+            return
+
+        service_point_values = {
+            loan.service_point_id for loan in self.semi_valid_legacy_loans if loan.service_point_id
+        }
+        logger.info(f"Validating {len(service_point_values)} unique service point values")
+
+        service_point_ids = {sp["id"] for sp in self.folio_client.service_points}
+        service_points_by_code = {
+            sp["code"]: sp["id"] for sp in self.folio_client.service_points if sp.get("code")
+        }
+
+        missing = [
+            v
+            for v in service_point_values
+            if v not in service_point_ids and v not in service_points_by_code
+        ]
+        if missing:
+            missing_uuids = [v for v in missing if is_uuid(v)]
+            missing_codes = [v for v in missing if not is_uuid(v)]
+            if missing_uuids:
+                logger.critical("Service point UUIDs not found in FOLIO: %s", missing_uuids)
+            if missing_codes:
+                logger.critical("Service point codes not found in FOLIO: %s", missing_codes)
+            sys.exit(1)
+
+        # Resolve codes to UUIDs for the circulation API
+        for loan in self.semi_valid_legacy_loans:
+            if loan.service_point_id and loan.service_point_id in service_points_by_code:
+                loan.service_point_id = service_points_by_code[loan.service_point_id]
+
     async def _pre_validate_barcodes(self):
         if self.task_configuration.skip_barcode_prevalidation:
             logger.info("Barcode pre-validation is disabled by configuration. Skipping.")
@@ -259,6 +383,7 @@ class LoansMigrator(MigrationTaskBase):
             )
 
     async def do_work(self):
+        await self.pre_validate_service_points()
         await self._pre_validate_barcodes()
         with self.folio_client.get_folio_http_client() as self.http_client:
             logger.info("Starting")
@@ -595,6 +720,7 @@ class LoansMigrator(MigrationTaskBase):
                     self.migration_report,
                     self.tenant_timezone,
                     legacy_loan_count,
+                    self.service_point_mapping,
                 )
                 if any(legacy_loan.errors):
                     num_bad += 1

--- a/src/folio_migration_tools/migration_tasks/loans_migrator.py
+++ b/src/folio_migration_tools/migration_tasks/loans_migrator.py
@@ -36,9 +36,6 @@ from folio_migration_tools.library_configuration import (
 from folio_migration_tools.mapping_file_transformation.mapping_file_mapper_base import (
     MappingFileMapperBase,
 )
-from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
-    RefDataMapping,
-)
 from folio_migration_tools.migration_report import MigrationReport
 from folio_migration_tools.migration_tasks.migration_task_base import MigrationTaskBase
 from folio_migration_tools.task_configuration import AbstractTaskConfiguration
@@ -46,7 +43,6 @@ from folio_migration_tools.transaction_migration.legacy_loan import LegacyLoan
 from folio_migration_tools.transaction_migration.transaction_result import (
     TransactionResult,
 )
-from folio_migration_tools.utils import is_uuid
 
 logger = logging.getLogger(__name__)
 
@@ -259,112 +255,6 @@ class LoansMigrator(MigrationTaskBase):
         else:
             logger.info("SMTP connection is disabled...")
 
-    def _init_service_point_mapping(self, task_configuration: TaskConfiguration):
-        """Initialize the service point mapping from an optional TSV file.
-
-        Args:
-            task_configuration (TaskConfiguration): Task configuration with mapping file name.
-        """
-        self.service_point_mapping: RefDataMapping | None = None
-        if task_configuration.service_point_map_file_name:
-            service_point_map = self.load_ref_data_mapping_file(
-                "servicePointId",
-                self.folder_structure.mapping_files_folder
-                / task_configuration.service_point_map_file_name,
-                ["servicePointId"],
-                False,
-            )
-            if service_point_map:
-                self.service_point_mapping = RefDataMapping(
-                    self.folio_client,
-                    "/service-points",
-                    "servicepoints",
-                    service_point_map,
-                    "code",
-                    "ServicePointMapping",
-                )
-
-    def _validate_fallback_service_point(self, fallback_service_point_id: str):
-        """Validate that the fallback service point exists in FOLIO.
-
-        Args:
-            fallback_service_point_id (str): The fallback service point ID (UUID or code).
-
-        Raises:
-            SystemExit: If fallback service point is not found in FOLIO.
-        """
-        if not fallback_service_point_id or not fallback_service_point_id.strip():
-            logger.info("No fallback service point configured")
-            return
-
-        try:
-            logger.info(f"Validating fallback service point: {fallback_service_point_id}")
-
-            # Build lookup structures for both ID (UUID) and code
-            service_point_ids = {sp["id"] for sp in self.folio_client.service_points}
-            service_points_by_code = {
-                sp["code"]: sp["id"] for sp in self.folio_client.service_points if sp.get("code")
-            }
-
-            # Check if fallback exists as UUID or code
-            if (
-                fallback_service_point_id not in service_point_ids
-                and fallback_service_point_id not in service_points_by_code
-            ):
-                logger.critical(
-                    "Fallback service point '%s' does not exist in FOLIO",
-                    fallback_service_point_id,
-                )
-                logger.critical(
-                    "Task initialization failed. Please verify fallback service point."
-                )
-                sys.exit(1)
-
-            logger.info(
-                f"Successfully validated fallback service point: {fallback_service_point_id}"
-            )
-
-        except Exception as e:
-            logger.exception("Error validating fallback service point: %s", e)
-            logger.critical(
-                "Task initialization failed due to fallback service point validation error"
-            )
-            sys.exit(1)
-
-    async def pre_validate_service_points(self):
-        """Validate all service point values exist in FOLIO, then resolve codes to UUIDs."""
-        if not self.semi_valid_legacy_loans:
-            return
-
-        service_point_values = {
-            loan.service_point_id for loan in self.semi_valid_legacy_loans if loan.service_point_id
-        }
-        logger.info(f"Validating {len(service_point_values)} unique service point values")
-
-        service_point_ids = {sp["id"] for sp in self.folio_client.service_points}
-        service_points_by_code = {
-            sp["code"]: sp["id"] for sp in self.folio_client.service_points if sp.get("code")
-        }
-
-        missing = [
-            v
-            for v in service_point_values
-            if v not in service_point_ids and v not in service_points_by_code
-        ]
-        if missing:
-            missing_uuids = [v for v in missing if is_uuid(v)]
-            missing_codes = [v for v in missing if not is_uuid(v)]
-            if missing_uuids:
-                logger.critical("Service point UUIDs not found in FOLIO: %s", missing_uuids)
-            if missing_codes:
-                logger.critical("Service point codes not found in FOLIO: %s", missing_codes)
-            sys.exit(1)
-
-        # Resolve codes to UUIDs for the circulation API
-        for loan in self.semi_valid_legacy_loans:
-            if loan.service_point_id and loan.service_point_id in service_points_by_code:
-                loan.service_point_id = service_points_by_code[loan.service_point_id]
-
     async def _pre_validate_barcodes(self):
         if self.task_configuration.skip_barcode_prevalidation:
             logger.info("Barcode pre-validation is disabled by configuration. Skipping.")
@@ -383,7 +273,7 @@ class LoansMigrator(MigrationTaskBase):
             )
 
     async def do_work(self):
-        await self.pre_validate_service_points()
+        self._pre_validate_service_points(self.semi_valid_legacy_loans, "service_point_id")
         await self._pre_validate_barcodes()
         with self.folio_client.get_folio_http_client() as self.http_client:
             logger.info("Starting")

--- a/src/folio_migration_tools/migration_tasks/migration_task_base.py
+++ b/src/folio_migration_tools/migration_tasks/migration_task_base.py
@@ -42,6 +42,10 @@ from folio_migration_tools.marc_rules_transformation.marc_reader_wrapper import 
     DEFAULT_MARC_RECORD_PREPROCESSORS,
     MARCReaderWrapper,
 )
+from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
+    RefDataMapping,
+)
+from folio_migration_tools.utils import is_uuid
 
 logger = logging.getLogger(__name__)
 
@@ -453,6 +457,115 @@ class MigrationTaskBase:
                 map_file_path,
             )
             return None
+
+    def _init_service_point_mapping(self, task_configuration):
+        """Initialize the service point mapping from an optional TSV file.
+
+        Args:
+            task_configuration: Task configuration with service_point_map_file_name attribute.
+        """
+        self.service_point_mapping: RefDataMapping | None = None
+        if task_configuration.service_point_map_file_name:
+            service_point_map = self.load_ref_data_mapping_file(
+                "servicePointId",
+                self.folder_structure.mapping_files_folder
+                / task_configuration.service_point_map_file_name,
+                ["servicePointId"],
+                False,
+            )
+            if service_point_map:
+                self.service_point_mapping = RefDataMapping(
+                    self.folio_client,
+                    "/service-points",
+                    "servicepoints",
+                    service_point_map,
+                    "code",
+                    "ServicePointMapping",
+                )
+
+    def _validate_fallback_service_point(self, fallback_service_point_id: str):
+        """Validate that the fallback service point exists in FOLIO.
+
+        Args:
+            fallback_service_point_id (str): The fallback service point ID (UUID or code).
+
+        Raises:
+            SystemExit: If fallback service point is not found in FOLIO.
+        """
+        if not fallback_service_point_id or not fallback_service_point_id.strip():
+            logger.info("No fallback service point configured")
+            return
+
+        try:
+            logger.info(f"Validating fallback service point: {fallback_service_point_id}")
+
+            service_point_ids = {sp["id"] for sp in self.folio_client.service_points}
+            service_points_by_code = {
+                sp["code"]: sp["id"] for sp in self.folio_client.service_points if sp.get("code")
+            }
+
+            if (
+                fallback_service_point_id not in service_point_ids
+                and fallback_service_point_id not in service_points_by_code
+            ):
+                logger.critical(
+                    "Fallback service point '%s' does not exist in FOLIO",
+                    fallback_service_point_id,
+                )
+                logger.critical(
+                    "Task initialization failed. Please verify fallback service point."
+                )
+                sys.exit(1)
+
+            logger.info(
+                f"Successfully validated fallback service point: {fallback_service_point_id}"
+            )
+
+        except Exception as e:
+            logger.exception("Error validating fallback service point: %s", e)
+            logger.critical(
+                "Task initialization failed due to fallback service point validation error"
+            )
+            sys.exit(1)
+
+    def _pre_validate_service_points(self, records, service_point_attr: str):
+        """Validate service point values exist in FOLIO and resolve codes to UUIDs.
+
+        Args:
+            records: List of legacy record objects.
+            service_point_attr: Attribute name on each record holding the service point value.
+        """
+        if not records:
+            return
+
+        service_point_values = {
+            getattr(r, service_point_attr) for r in records if getattr(r, service_point_attr, None)
+        }
+        logger.info(f"Validating {len(service_point_values)} unique service point values")
+
+        service_point_ids = {sp["id"] for sp in self.folio_client.service_points}
+        service_points_by_code = {
+            sp["code"]: sp["id"] for sp in self.folio_client.service_points if sp.get("code")
+        }
+
+        missing = [
+            v
+            for v in service_point_values
+            if v not in service_point_ids and v not in service_points_by_code
+        ]
+        if missing:
+            missing_uuids = [v for v in missing if is_uuid(v)]
+            missing_codes = [v for v in missing if not is_uuid(v)]
+            if missing_uuids:
+                logger.critical("Service point UUIDs not found in FOLIO: %s", missing_uuids)
+            if missing_codes:
+                logger.critical("Service point codes not found in FOLIO: %s", missing_codes)
+            sys.exit(1)
+
+        for record in records:
+            val = getattr(record, service_point_attr, None)
+            if val and val in service_points_by_code:
+                setattr(record, service_point_attr, service_points_by_code[val])
 
 
 class MarcTaskConfigurationBase(task_configuration.AbstractTaskConfiguration):

--- a/src/folio_migration_tools/migration_tasks/requests_migrator.py
+++ b/src/folio_migration_tools/migration_tasks/requests_migrator.py
@@ -32,14 +32,10 @@ from folio_migration_tools.library_configuration import (
 from folio_migration_tools.mapping_file_transformation.mapping_file_mapper_base import (
     get_from_path,
 )
-from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
-    RefDataMapping,
-)
 from folio_migration_tools.migration_report import MigrationReport
 from folio_migration_tools.migration_tasks.migration_task_base import MigrationTaskBase
 from folio_migration_tools.task_configuration import AbstractTaskConfiguration
 from folio_migration_tools.transaction_migration.legacy_request import LegacyRequest
-from folio_migration_tools.utils import is_uuid
 
 logger = logging.getLogger(__name__)
 
@@ -258,47 +254,6 @@ class RequestsMigrator(MigrationTaskBase):
                 return values[0]
         return None
 
-    async def pre_validate_service_points(self):
-        """Validate all service point values exist in FOLIO, then resolve codes to UUIDs."""
-        if not self.semi_valid_legacy_requests:
-            return
-
-        service_point_values = {
-            r.pickup_servicepoint_id
-            for r in self.semi_valid_legacy_requests
-            if r.pickup_servicepoint_id
-        }
-        logger.info(f"Validating {len(service_point_values)} unique service point values")
-
-        service_point_ids = {sp["id"] for sp in self.folio_client.service_points}
-        service_points_by_code = {
-            sp["code"]: sp["id"] for sp in self.folio_client.service_points if sp.get("code")
-        }
-
-        missing = [
-            v
-            for v in service_point_values
-            if v not in service_point_ids and v not in service_points_by_code
-        ]
-        if missing:
-            missing_uuids = [v for v in missing if is_uuid(v)]
-            missing_codes = [v for v in missing if not is_uuid(v)]
-            if missing_uuids:
-                logger.critical("Service point UUIDs not found in FOLIO: %s", missing_uuids)
-            if missing_codes:
-                logger.critical("Service point codes not found in FOLIO: %s", missing_codes)
-            sys.exit(1)
-
-        # Resolve codes to UUIDs for the circulation API
-        for request in self.semi_valid_legacy_requests:
-            if (
-                request.pickup_servicepoint_id
-                and request.pickup_servicepoint_id in service_points_by_code
-            ):
-                request.pickup_servicepoint_id = service_points_by_code[
-                    request.pickup_servicepoint_id
-                ]
-
     async def _pre_validate_barcodes(self):
         if self.task_configuration.skip_barcode_prevalidation:
             logger.info("Barcode pre-validation is disabled by configuration. Skipping.")
@@ -364,7 +319,9 @@ class RequestsMigrator(MigrationTaskBase):
         return True, legacy_request
 
     async def do_work(self):
-        await self.pre_validate_service_points()
+        self._pre_validate_service_points(
+            self.semi_valid_legacy_requests, "pickup_servicepoint_id"
+        )
         await self._pre_validate_barcodes()
         logger.info("Starting")
         if self.task_configuration.starting_row > 1:
@@ -668,78 +625,6 @@ class RequestsMigrator(MigrationTaskBase):
                 "No item found for barcode",
                 f"Barcode: {barcode}",
             )
-
-    def _init_service_point_mapping(self, task_configuration: TaskConfiguration):
-        """Initialize the service point mapping from an optional TSV file.
-
-        Args:
-            task_configuration (TaskConfiguration): Task configuration with mapping file name.
-        """
-        self.service_point_mapping: RefDataMapping | None = None
-        if task_configuration.service_point_map_file_name:
-            service_point_map = self.load_ref_data_mapping_file(
-                "servicePointId",
-                self.folder_structure.mapping_files_folder
-                / task_configuration.service_point_map_file_name,
-                ["servicePointId"],
-                False,
-            )
-            if service_point_map:
-                self.service_point_mapping = RefDataMapping(
-                    self.folio_client,
-                    "/service-points",
-                    "servicepoints",
-                    service_point_map,
-                    "code",
-                    "ServicePointMapping",
-                )
-
-    def _validate_fallback_service_point(self, fallback_service_point_id: str):
-        """Validate that the fallback service point exists in FOLIO.
-
-        Args:
-            fallback_service_point_id (str): The fallback service point ID (UUID or code).
-
-        Raises:
-            SystemExit: If fallback service point is not found in FOLIO.
-        """
-        if not fallback_service_point_id or not fallback_service_point_id.strip():
-            logger.info("No fallback service point configured")
-            return
-
-        try:
-            logger.info(f"Validating fallback service point: {fallback_service_point_id}")
-
-            # Build lookup structures for both ID (UUID) and code
-            service_point_ids = {sp["id"] for sp in self.folio_client.service_points}
-            service_points_by_code = {
-                sp["code"]: sp["id"] for sp in self.folio_client.service_points if sp.get("code")
-            }
-
-            # Check if fallback exists as UUID or code
-            if (
-                fallback_service_point_id not in service_point_ids
-                and fallback_service_point_id not in service_points_by_code
-            ):
-                logger.critical(
-                    "Fallback service point '%s' does not exist in FOLIO",
-                    fallback_service_point_id,
-                )
-                logger.critical(
-                    "Task initialization failed. Please verify fallback service point."
-                )
-                sys.exit(1)
-
-            logger.info(
-                f"Successfully validated fallback service point: {fallback_service_point_id}"
-            )
-
-        except Exception as e:
-            logger.exception("Error validating fallback service point: %s", e)
-            logger.critical(
-                "Task initialization failed due to fallback service point validation error"
-            )
-            sys.exit(1)
 
     async def check_barcodes(self) -> AsyncGenerator[LegacyRequest, None]:
         self.pre_validate_item_barcodes()

--- a/src/folio_migration_tools/migration_tasks/requests_migrator.py
+++ b/src/folio_migration_tools/migration_tasks/requests_migrator.py
@@ -32,10 +32,14 @@ from folio_migration_tools.library_configuration import (
 from folio_migration_tools.mapping_file_transformation.mapping_file_mapper_base import (
     get_from_path,
 )
+from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
+    RefDataMapping,
+)
 from folio_migration_tools.migration_report import MigrationReport
 from folio_migration_tools.migration_tasks.migration_task_base import MigrationTaskBase
 from folio_migration_tools.task_configuration import AbstractTaskConfiguration
 from folio_migration_tools.transaction_migration.legacy_request import LegacyRequest
+from folio_migration_tools.utils import is_uuid
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +91,27 @@ class RequestsMigrator(MigrationTaskBase):
                 ),
             ),
         ] = False
+        service_point_map_file_name: Annotated[
+            Optional[str],
+            Field(
+                title="Service point map file name",
+                description=(
+                    "Optional file name for service point mapping. Maps legacy service point "
+                    "codes to FOLIO service point codes."
+                ),
+            ),
+        ] = ""
+        fallback_service_point_id: Annotated[
+            str,
+            Field(
+                title="Fallback service point ID",
+                description=(
+                    "Fallback service point ID (UUID or code) to use when request "
+                    "does not specify a pickup service point."
+                ),
+                min_length=1,
+            ),
+        ]
 
     @staticmethod
     def get_object_type() -> FOLIONamespaces:
@@ -114,6 +139,8 @@ class RequestsMigrator(MigrationTaskBase):
             "",
             self.migration_report,
         )
+        self._init_service_point_mapping(task_configuration)
+        self._validate_fallback_service_point(task_configuration.fallback_service_point_id)
         self.valid_patron_map = {}
         self.valid_item_barcodes = set()
         try:
@@ -231,6 +258,47 @@ class RequestsMigrator(MigrationTaskBase):
                 return values[0]
         return None
 
+    async def pre_validate_service_points(self):
+        """Validate all service point values exist in FOLIO, then resolve codes to UUIDs."""
+        if not self.semi_valid_legacy_requests:
+            return
+
+        service_point_values = {
+            r.pickup_servicepoint_id
+            for r in self.semi_valid_legacy_requests
+            if r.pickup_servicepoint_id
+        }
+        logger.info(f"Validating {len(service_point_values)} unique service point values")
+
+        service_point_ids = {sp["id"] for sp in self.folio_client.service_points}
+        service_points_by_code = {
+            sp["code"]: sp["id"] for sp in self.folio_client.service_points if sp.get("code")
+        }
+
+        missing = [
+            v
+            for v in service_point_values
+            if v not in service_point_ids and v not in service_points_by_code
+        ]
+        if missing:
+            missing_uuids = [v for v in missing if is_uuid(v)]
+            missing_codes = [v for v in missing if not is_uuid(v)]
+            if missing_uuids:
+                logger.critical("Service point UUIDs not found in FOLIO: %s", missing_uuids)
+            if missing_codes:
+                logger.critical("Service point codes not found in FOLIO: %s", missing_codes)
+            sys.exit(1)
+
+        # Resolve codes to UUIDs for the circulation API
+        for request in self.semi_valid_legacy_requests:
+            if (
+                request.pickup_servicepoint_id
+                and request.pickup_servicepoint_id in service_points_by_code
+            ):
+                request.pickup_servicepoint_id = service_points_by_code[
+                    request.pickup_servicepoint_id
+                ]
+
     async def _pre_validate_barcodes(self):
         if self.task_configuration.skip_barcode_prevalidation:
             logger.info("Barcode pre-validation is disabled by configuration. Skipping.")
@@ -296,6 +364,7 @@ class RequestsMigrator(MigrationTaskBase):
         return True, legacy_request
 
     async def do_work(self):
+        await self.pre_validate_service_points()
         await self._pre_validate_barcodes()
         logger.info("Starting")
         if self.task_configuration.starting_row > 1:
@@ -600,6 +669,78 @@ class RequestsMigrator(MigrationTaskBase):
                 f"Barcode: {barcode}",
             )
 
+    def _init_service_point_mapping(self, task_configuration: TaskConfiguration):
+        """Initialize the service point mapping from an optional TSV file.
+
+        Args:
+            task_configuration (TaskConfiguration): Task configuration with mapping file name.
+        """
+        self.service_point_mapping: RefDataMapping | None = None
+        if task_configuration.service_point_map_file_name:
+            service_point_map = self.load_ref_data_mapping_file(
+                "servicePointId",
+                self.folder_structure.mapping_files_folder
+                / task_configuration.service_point_map_file_name,
+                ["servicePointId"],
+                False,
+            )
+            if service_point_map:
+                self.service_point_mapping = RefDataMapping(
+                    self.folio_client,
+                    "/service-points",
+                    "servicepoints",
+                    service_point_map,
+                    "code",
+                    "ServicePointMapping",
+                )
+
+    def _validate_fallback_service_point(self, fallback_service_point_id: str):
+        """Validate that the fallback service point exists in FOLIO.
+
+        Args:
+            fallback_service_point_id (str): The fallback service point ID (UUID or code).
+
+        Raises:
+            SystemExit: If fallback service point is not found in FOLIO.
+        """
+        if not fallback_service_point_id or not fallback_service_point_id.strip():
+            logger.info("No fallback service point configured")
+            return
+
+        try:
+            logger.info(f"Validating fallback service point: {fallback_service_point_id}")
+
+            # Build lookup structures for both ID (UUID) and code
+            service_point_ids = {sp["id"] for sp in self.folio_client.service_points}
+            service_points_by_code = {
+                sp["code"]: sp["id"] for sp in self.folio_client.service_points if sp.get("code")
+            }
+
+            # Check if fallback exists as UUID or code
+            if (
+                fallback_service_point_id not in service_point_ids
+                and fallback_service_point_id not in service_points_by_code
+            ):
+                logger.critical(
+                    "Fallback service point '%s' does not exist in FOLIO",
+                    fallback_service_point_id,
+                )
+                logger.critical(
+                    "Task initialization failed. Please verify fallback service point."
+                )
+                sys.exit(1)
+
+            logger.info(
+                f"Successfully validated fallback service point: {fallback_service_point_id}"
+            )
+
+        except Exception as e:
+            logger.exception("Error validating fallback service point: %s", e)
+            logger.critical(
+                "Task initialization failed due to fallback service point validation error"
+            )
+            sys.exit(1)
+
     async def check_barcodes(self) -> AsyncGenerator[LegacyRequest, None]:
         self.pre_validate_item_barcodes()
         await self.pre_validate_patron_barcodes_async()
@@ -652,6 +793,8 @@ class RequestsMigrator(MigrationTaskBase):
                     legacy_request_dict,
                     self.tenant_timezone,
                     legacy_reques_count,
+                    self.service_point_mapping,
+                    self.task_configuration.fallback_service_point_id,
                 )
                 if any(legacy_request.errors):
                     num_bad += 1

--- a/src/folio_migration_tools/migration_tasks/user_importer.py
+++ b/src/folio_migration_tools/migration_tasks/user_importer.py
@@ -148,6 +148,14 @@ class UserImportTask(MigrationTaskBase):
             ),
         ] = False
 
+        handle_permissions_user_objects: Annotated[
+            bool,
+            Field(
+                title="Handle permission user objects",
+                description="Whether to handle permission user objects when updating users.",
+            ),
+        ] = True
+
     task_configuration: TaskConfiguration
 
     @staticmethod
@@ -198,6 +206,7 @@ class UserImportTask(MigrationTaskBase):
             limit_simultaneous_requests=self.task_configuration.limit_simultaneous_requests,
             user_file_paths=file_paths,
             no_progress=self.task_configuration.no_progress,
+            handle_permissions_user_objects=self.task_configuration.handle_permissions_user_objects,
         )
 
     async def do_work(self) -> None:

--- a/src/folio_migration_tools/transaction_migration/legacy_loan.py
+++ b/src/folio_migration_tools/transaction_migration/legacy_loan.py
@@ -20,7 +20,7 @@ from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
     RefDataMapping,
 )
 from folio_migration_tools.migration_report import MigrationReport
-from folio_migration_tools.utils import is_uuid
+from folio_migration_tools.utils import resolve_service_point_value
 
 logger = logging.getLogger(__name__)
 
@@ -145,62 +145,14 @@ class LegacyLoan(object):
         self.next_item_status = self.legacy_loan_dict.get("next_item_status", "").strip()
         if self.next_item_status not in legal_statuses:
             self.errors.append((f"Not an allowed status {row=}", self.next_item_status))
-        self.service_point_id = self._get_service_point_value(
-            fallback_service_point_id, service_point_mapping
+        self.service_point_id = resolve_service_point_value(
+            self.legacy_loan_dict,
+            "service_point_id",
+            fallback_service_point_id,
+            service_point_mapping,
+            self.row,
+            self.errors,
         )
-
-    def _get_service_point_value(
-        self, fallback_service_point_id: str, service_point_mapping: RefDataMapping | None
-    ):
-        """Resolve service point code or id from source data or mapping.
-
-        Args:
-            fallback_service_point_id (str): Fallback service point ID.
-            service_point_mapping: Optional RefDataMapping for service point code resolution.
-
-        Returns:
-            str: Resolved service point ID.
-        """
-        raw_value = self.legacy_loan_dict.get("service_point_id", "").strip()
-
-        # Empty value → use fallback
-        if not raw_value:
-            raw_value = fallback_service_point_id
-
-        # UUID value → pass through unchanged (will be validated later)
-        if is_uuid(raw_value):
-            return raw_value
-
-        # Code value with mapping
-        if service_point_mapping:
-            try:
-                mapping = service_point_mapping.get_ref_data_mapping(
-                    {"service_point_id": raw_value}
-                )
-                if mapping and "folio_id" in mapping:
-                    return mapping["folio_id"]
-                else:
-                    self.errors.append(
-                        (
-                            f"Service point code not found in mapping in row {self.row}",
-                            raw_value,
-                        )
-                    )
-                    return ""
-            except Exception as e:
-                logger.warning(
-                    f"Error resolving service point '{raw_value}' in row {self.row}: {e}"
-                )
-                self.errors.append(
-                    (
-                        f"Error resolving service point code in row {self.row}",
-                        raw_value,
-                    )
-                )
-                return ""
-
-        # Code value without mapping → return as-is (will be validated later)
-        return raw_value
 
     def set_renewal_count(self, loan: dict) -> int:
         if "renewal_count" in loan:

--- a/src/folio_migration_tools/transaction_migration/legacy_loan.py
+++ b/src/folio_migration_tools/transaction_migration/legacy_loan.py
@@ -16,7 +16,11 @@ from dateutil.parser import ParserError, parse
 
 from folio_migration_tools.custom_exceptions import TransformationRecordFailedError
 from folio_migration_tools.helper import Helper
+from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
+    RefDataMapping,
+)
 from folio_migration_tools.migration_report import MigrationReport
+from folio_migration_tools.utils import is_uuid
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +35,7 @@ class LegacyLoan(object):
         migration_report: MigrationReport,
         tenant_timezone=utc,
         row=0,
+        service_point_mapping: RefDataMapping | None = None,
     ):
         """Initialize LegacyLoan from legacy loan data.
 
@@ -40,6 +45,7 @@ class LegacyLoan(object):
             migration_report (MigrationReport): Report for tracking issues.
             tenant_timezone: Timezone of the tenant (default: UTC).
             row (int): Row number in source data for error reporting.
+            service_point_mapping: Optional RefDataMapping for service point code resolution.
         """
         self.migration_report: MigrationReport = migration_report
         # validate
@@ -139,11 +145,62 @@ class LegacyLoan(object):
         self.next_item_status = self.legacy_loan_dict.get("next_item_status", "").strip()
         if self.next_item_status not in legal_statuses:
             self.errors.append((f"Not an allowed status {row=}", self.next_item_status))
-        self.service_point_id = (
-            self.legacy_loan_dict["service_point_id"]
-            if self.legacy_loan_dict.get("service_point_id", "")
-            else fallback_service_point_id
+        self.service_point_id = self._get_service_point_value(
+            fallback_service_point_id, service_point_mapping
         )
+
+    def _get_service_point_value(
+        self, fallback_service_point_id: str, service_point_mapping: RefDataMapping | None
+    ):
+        """Resolve service point code or id from source data or mapping.
+
+        Args:
+            fallback_service_point_id (str): Fallback service point ID.
+            service_point_mapping: Optional RefDataMapping for service point code resolution.
+
+        Returns:
+            str: Resolved service point ID.
+        """
+        raw_value = self.legacy_loan_dict.get("service_point_id", "").strip()
+
+        # Empty value → use fallback
+        if not raw_value:
+            raw_value = fallback_service_point_id
+
+        # UUID value → pass through unchanged (will be validated later)
+        if is_uuid(raw_value):
+            return raw_value
+
+        # Code value with mapping
+        if service_point_mapping:
+            try:
+                mapping = service_point_mapping.get_ref_data_mapping(
+                    {"service_point_id": raw_value}
+                )
+                if mapping and "folio_id" in mapping:
+                    return mapping["folio_id"]
+                else:
+                    self.errors.append(
+                        (
+                            f"Service point code not found in mapping in row {self.row}",
+                            raw_value,
+                        )
+                    )
+                    return ""
+            except Exception as e:
+                logger.warning(
+                    f"Error resolving service point '{raw_value}' in row {self.row}: {e}"
+                )
+                self.errors.append(
+                    (
+                        f"Error resolving service point code in row {self.row}",
+                        raw_value,
+                    )
+                )
+                return ""
+
+        # Code value without mapping → return as-is (will be validated later)
+        return raw_value
 
     def set_renewal_count(self, loan: dict) -> int:
         if "renewal_count" in loan:

--- a/src/folio_migration_tools/transaction_migration/legacy_request.py
+++ b/src/folio_migration_tools/transaction_migration/legacy_request.py
@@ -17,7 +17,7 @@ from folio_migration_tools.custom_exceptions import TransformationRecordFailedEr
 from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
     RefDataMapping,
 )
-from folio_migration_tools.utils import is_uuid
+from folio_migration_tools.utils import resolve_service_point_value
 
 logger = logging.getLogger(__name__)
 
@@ -69,8 +69,13 @@ class LegacyRequest(object):
         self.patron_barcode = legacy_request_dict["patron_barcode"].strip()
         self.comment = legacy_request_dict["comment"].strip()
         self.request_type = legacy_request_dict["request_type"].strip()
-        self.pickup_servicepoint_id = self._get_service_point_value(
-            legacy_request_dict, fallback_service_point_id, service_point_mapping
+        self.pickup_servicepoint_id = resolve_service_point_value(
+            legacy_request_dict,
+            "pickup_servicepoint_id",
+            fallback_service_point_id,
+            service_point_mapping,
+            self.row,
+            self.errors,
         )
         self.fulfillment_preference = "Hold Shelf"
 
@@ -99,63 +104,6 @@ class LegacyRequest(object):
         self.request_date: datetime.datetime = temp_request_date
         self.request_expiration_date: datetime.datetime = temp_expiration_date
         self.correct_for_1_day_requests()
-
-    def _get_service_point_value(
-        self,
-        legacy_request_dict,
-        fallback_service_point_id,
-        service_point_mapping: RefDataMapping | None,
-    ):
-        """Resolve service point ID from source data or mapping.
-
-        Args:
-            legacy_request_dict: Dictionary containing legacy request data.
-            fallback_service_point_id: Fallback service point ID to use if not in source data.
-            service_point_mapping: Optional RefDataMapping for service point code resolution.
-
-        Returns:
-            str: Resolved service point ID.
-        """
-        raw_value = legacy_request_dict.get("pickup_servicepoint_id", "").strip()
-
-        # Empty value → use fallback
-        if not raw_value:
-            raw_value = fallback_service_point_id
-
-        # UUID value → pass through unchanged (will be validated later)
-        if is_uuid(raw_value):
-            return raw_value
-
-        # Code value with mapping
-        if service_point_mapping:
-            try:
-                mapping = service_point_mapping.get_ref_data_mapping(
-                    {"service_point_id": raw_value}
-                )
-                if mapping and "folio_id" in mapping:
-                    return mapping["folio_id"]
-                else:
-                    self.errors.append(
-                        (
-                            f"Service point code not found in mapping in row {self.row}",
-                            raw_value,
-                        )
-                    )
-                    return ""
-            except Exception as e:
-                logger.warning(
-                    f"Error resolving service point '{raw_value}' in row {self.row}: {e}"
-                )
-                self.errors.append(
-                    (
-                        f"Error resolving service point code in row {self.row}",
-                        raw_value,
-                    )
-                )
-                return ""
-
-        # Code value without mapping → return as-is (will be validated later)
-        return raw_value
 
     def correct_for_1_day_requests(self):
         try:

--- a/src/folio_migration_tools/transaction_migration/legacy_request.py
+++ b/src/folio_migration_tools/transaction_migration/legacy_request.py
@@ -14,6 +14,10 @@ from dateutil import tz
 from dateutil.parser import parse
 
 from folio_migration_tools.custom_exceptions import TransformationRecordFailedError
+from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
+    RefDataMapping,
+)
+from folio_migration_tools.utils import is_uuid
 
 logger = logging.getLogger(__name__)
 
@@ -21,13 +25,22 @@ utc = ZoneInfo("UTC")
 
 
 class LegacyRequest(object):
-    def __init__(self, legacy_request_dict, tenant_timezone=utc, row=0):
+    def __init__(
+        self,
+        legacy_request_dict,
+        tenant_timezone=utc,
+        row=0,
+        service_point_mapping: RefDataMapping | None = None,
+        fallback_service_point_id="",
+    ):
         """Initialize LegacyRequest from legacy request data.
 
         Args:
             legacy_request_dict: Dictionary containing legacy request data.
             tenant_timezone: Timezone of the tenant (default: UTC).
             row (int): Row number in source data for error reporting.
+            service_point_mapping: Optional RefDataMapping for service point code resolution.
+            fallback_service_point_id: Fallback service point ID to use if not in source data.
         """
         # validate
         correct_headers = [
@@ -37,9 +50,9 @@ class LegacyRequest(object):
             "request_expiration_date",
             "comment",
             "request_type",
-            "pickup_servicepoint_id",
         ]
         self.errors = []
+        self.row = row
 
         for prop in correct_headers:
             if prop not in legacy_request_dict:
@@ -56,7 +69,9 @@ class LegacyRequest(object):
         self.patron_barcode = legacy_request_dict["patron_barcode"].strip()
         self.comment = legacy_request_dict["comment"].strip()
         self.request_type = legacy_request_dict["request_type"].strip()
-        self.pickup_servicepoint_id = legacy_request_dict["pickup_servicepoint_id"].strip()
+        self.pickup_servicepoint_id = self._get_service_point_value(
+            legacy_request_dict, fallback_service_point_id, service_point_mapping
+        )
         self.fulfillment_preference = "Hold Shelf"
 
         if self.request_type not in ["Hold", "Recall", "Page"]:
@@ -84,6 +99,63 @@ class LegacyRequest(object):
         self.request_date: datetime.datetime = temp_request_date
         self.request_expiration_date: datetime.datetime = temp_expiration_date
         self.correct_for_1_day_requests()
+
+    def _get_service_point_value(
+        self,
+        legacy_request_dict,
+        fallback_service_point_id,
+        service_point_mapping: RefDataMapping | None,
+    ):
+        """Resolve service point ID from source data or mapping.
+
+        Args:
+            legacy_request_dict: Dictionary containing legacy request data.
+            fallback_service_point_id: Fallback service point ID to use if not in source data.
+            service_point_mapping: Optional RefDataMapping for service point code resolution.
+
+        Returns:
+            str: Resolved service point ID.
+        """
+        raw_value = legacy_request_dict.get("pickup_servicepoint_id", "").strip()
+
+        # Empty value → use fallback
+        if not raw_value:
+            raw_value = fallback_service_point_id
+
+        # UUID value → pass through unchanged (will be validated later)
+        if is_uuid(raw_value):
+            return raw_value
+
+        # Code value with mapping
+        if service_point_mapping:
+            try:
+                mapping = service_point_mapping.get_ref_data_mapping(
+                    {"service_point_id": raw_value}
+                )
+                if mapping and "folio_id" in mapping:
+                    return mapping["folio_id"]
+                else:
+                    self.errors.append(
+                        (
+                            f"Service point code not found in mapping in row {self.row}",
+                            raw_value,
+                        )
+                    )
+                    return ""
+            except Exception as e:
+                logger.warning(
+                    f"Error resolving service point '{raw_value}' in row {self.row}: {e}"
+                )
+                self.errors.append(
+                    (
+                        f"Error resolving service point code in row {self.row}",
+                        raw_value,
+                    )
+                )
+                return ""
+
+        # Code value without mapping → return as-is (will be validated later)
+        return raw_value
 
     def correct_for_1_day_requests(self):
         try:

--- a/src/folio_migration_tools/utils.py
+++ b/src/folio_migration_tools/utils.py
@@ -1,7 +1,10 @@
 """Generic utility helpers shared across folio_migration_tools modules."""
 
+import logging
 import re
 import uuid
+
+logger = logging.getLogger(__name__)
 
 
 def is_uuid(value: str) -> bool:
@@ -11,6 +14,61 @@ def is_uuid(value: str) -> bool:
         return True
     except (ValueError, AttributeError, TypeError):
         return False
+
+
+def resolve_service_point_value(
+    source_dict: dict,
+    source_key: str,
+    fallback_service_point_id: str,
+    service_point_mapping,
+    row: int,
+    errors: list,
+) -> str:
+    """Resolve a service point value from source data, fallback, or mapping.
+
+    Args:
+        source_dict: Dictionary containing the source record data.
+        source_key: Key to look up the service point value in source_dict.
+        fallback_service_point_id: Fallback value when source data is empty.
+        service_point_mapping: Optional RefDataMapping for code-to-UUID resolution.
+        row: Row number for error reporting.
+        errors: Error list to append to on failure.
+
+    Returns:
+        str: Resolved service point value (UUID, code, or empty on error).
+    """
+    raw_value = source_dict.get(source_key, "").strip()
+
+    if not raw_value:
+        raw_value = fallback_service_point_id
+
+    if is_uuid(raw_value):
+        return raw_value
+
+    if service_point_mapping:
+        try:
+            mapping = service_point_mapping.get_ref_data_mapping({"service_point_id": raw_value})
+            if mapping and "folio_id" in mapping:
+                return mapping["folio_id"]
+            else:
+                errors.append(
+                    (
+                        f"Service point code not found in mapping in row {row}",
+                        raw_value,
+                    )
+                )
+                return ""
+        except Exception as e:
+            logger.warning(f"Error resolving service point '{raw_value}' in row {row}: {e}")
+            errors.append(
+                (
+                    f"Error resolving service point code in row {row}",
+                    raw_value,
+                )
+            )
+            return ""
+
+    return raw_value
 
 
 def normalize_for_compare(value):

--- a/src/folio_migration_tools/utils.py
+++ b/src/folio_migration_tools/utils.py
@@ -1,6 +1,16 @@
 """Generic utility helpers shared across folio_migration_tools modules."""
 
 import re
+import uuid
+
+
+def is_uuid(value: str) -> bool:
+    """Check if a string value is a valid UUID."""
+    try:
+        uuid.UUID(str(value))
+        return True
+    except (ValueError, AttributeError, TypeError):
+        return False
 
 
 def normalize_for_compare(value):

--- a/tests/test_loans_migrator.py
+++ b/tests/test_loans_migrator.py
@@ -9,8 +9,12 @@ import pytest
 from folio_uuid.folio_namespaces import FOLIONamespaces
 
 from folio_migration_tools.library_configuration import LibraryConfiguration
+from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
+    RefDataMapping,
+)
 from folio_migration_tools.migration_report import MigrationReport
 from folio_migration_tools.migration_tasks.loans_migrator import LoansMigrator
+from .test_infrastructure import mocked_classes
 
 
 def test_get_object_type():
@@ -53,6 +57,9 @@ def test_load_and_validate_legacy_loans_set_in_source():
         mock_migrator = Mock(spec=LoansMigrator)
         mock_migrator.tenant_timezone = ZoneInfo("UTC")
         mock_migrator.migration_report = MigrationReport()
+        mock_migrator.service_point_mapping = None
+        mock_migrator.failed = {}
+        mock_migrator.failed_and_not_dupe = {}
         a = LoansMigrator.load_and_validate_legacy_loans(
             mock_migrator, reader, "Set on file or config"
         )
@@ -93,6 +100,9 @@ def test_load_and_validate_legacy_loans_set_centrally():
         mock_migrator = Mock(spec=LoansMigrator)
         mock_migrator.migration_report = MigrationReport()
         mock_migrator.tenant_timezone = ZoneInfo("UTC")
+        mock_migrator.service_point_mapping = None
+        mock_migrator.failed = {}
+        mock_migrator.failed_and_not_dupe = {}
         a = LoansMigrator.load_and_validate_legacy_loans(
             mock_migrator, reader, "Set on file or config"
         )
@@ -135,6 +145,9 @@ def test_load_and_validate_legacy_loans_with_proxy():
         mock_migrator = Mock(spec=LoansMigrator)
         mock_migrator.migration_report = MigrationReport()
         mock_migrator.tenant_timezone = ZoneInfo("UTC")
+        mock_migrator.service_point_mapping = None
+        mock_migrator.failed = {}
+        mock_migrator.failed_and_not_dupe = {}
         a = LoansMigrator.load_and_validate_legacy_loans(
             mock_migrator, reader, "Set on file or config"
         )
@@ -599,3 +612,56 @@ def test_declare_lost_uses_fallback_service_point_id_without_cast(mock_i18n):
 
         assert result == []
         assert "I001" in m.failed
+
+
+class TestServicePointMappingInit:
+    """Test _init_service_point_mapping using real RefDataMapping and mocked FolioClient."""
+
+    def test_creates_ref_data_mapping_from_tsv_file(self, tmp_path):
+        """Integration: loads a real TSV mapping file and produces a RefDataMapping."""
+        import csv
+
+        csv.register_dialect("tsv", delimiter="\t")
+        map_file = tmp_path / "sp_map.tsv"
+        map_file.write_text("service_point_id\tfolio_code\nold_desk\tlmd\n*\tfo\n")
+
+        m = Mock(spec=LoansMigrator)
+        m.folio_client = mocked_classes.mocked_folio_client()
+        m.folder_structure = Mock()
+        m.folder_structure.mapping_files_folder = tmp_path
+        m.load_ref_data_mapping_file = LoansMigrator.load_ref_data_mapping_file
+
+        task_config = Mock()
+        task_config.service_point_map_file_name = "sp_map.tsv"
+
+        LoansMigrator._init_service_point_mapping(m, task_config)
+
+        assert isinstance(m.service_point_mapping, RefDataMapping)
+        assert m.service_point_mapping.default_id == "finance_office_uuid"
+        assert m.service_point_mapping.regular_mappings[0]["folio_id"] == "library_main_desk_uuid"
+
+    def test_skips_loading_when_no_map_file_configured(self):
+        m = Mock(spec=LoansMigrator)
+        m.load_ref_data_mapping_file = LoansMigrator.load_ref_data_mapping_file
+
+        task_config = Mock()
+        task_config.service_point_map_file_name = ""
+
+        LoansMigrator._init_service_point_mapping(m, task_config)
+
+        assert m.service_point_mapping is None
+
+    def test_sets_none_when_map_file_does_not_exist(self, tmp_path):
+        """When the configured file doesn't exist, service_point_mapping stays None."""
+        m = Mock(spec=LoansMigrator)
+        m.folio_client = mocked_classes.mocked_folio_client()
+        m.folder_structure = Mock()
+        m.folder_structure.mapping_files_folder = tmp_path
+        m.load_ref_data_mapping_file = LoansMigrator.load_ref_data_mapping_file
+
+        task_config = Mock()
+        task_config.service_point_map_file_name = "nonexistent.tsv"
+
+        LoansMigrator._init_service_point_mapping(m, task_config)
+
+        assert m.service_point_mapping is None

--- a/tests/test_requests_migrator.py
+++ b/tests/test_requests_migrator.py
@@ -1,9 +1,13 @@
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, PropertyMock
 
 import pytest
 from folio_uuid.folio_namespaces import FOLIONamespaces
 
+from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
+    RefDataMapping,
+)
 from folio_migration_tools.migration_tasks.requests_migrator import RequestsMigrator
+from .test_infrastructure import mocked_classes
 
 
 def test_get_object_type():
@@ -15,9 +19,11 @@ class DummyLegacyRequest:
         self,
         item_barcode: str = "item-1",
         patron_barcode: str = "patron-1",
+        pickup_servicepoint_id: str = "",
     ):
         self.item_barcode = item_barcode
         self.patron_barcode = patron_barcode
+        self.pickup_servicepoint_id = pickup_servicepoint_id
         self.request_date = 1
 
     def to_source_dict(self):
@@ -195,3 +201,118 @@ class TestPreValidateBarcodesWorkflow:
         await RequestsMigrator._pre_validate_barcodes(m)
 
         assert m.valid_legacy_requests == [req1]
+
+
+class TestPreValidateServicePoints:
+    def _make_migrator(self, requests, folio_service_points=None):
+        m = Mock(spec=RequestsMigrator)
+        m.semi_valid_legacy_requests = requests
+        m.folio_client = Mock()
+        m.folio_client.service_points = folio_service_points or []
+        return m
+
+    @pytest.mark.asyncio
+    async def test_resolves_code_to_uuid(self):
+        req = DummyLegacyRequest(pickup_servicepoint_id="circ-desk")
+        folio_sps = [{"id": "sp-uuid-1", "code": "circ-desk"}]
+        m = self._make_migrator([req], folio_sps)
+
+        await RequestsMigrator.pre_validate_service_points(m)
+
+        assert req.pickup_servicepoint_id == "sp-uuid-1"
+
+    @pytest.mark.asyncio
+    async def test_uuid_passes_through_unchanged(self):
+        req = DummyLegacyRequest(pickup_servicepoint_id="sp-uuid-1")
+        folio_sps = [{"id": "sp-uuid-1", "code": "circ-desk"}]
+        m = self._make_migrator([req], folio_sps)
+
+        await RequestsMigrator.pre_validate_service_points(m)
+
+        assert req.pickup_servicepoint_id == "sp-uuid-1"
+
+    @pytest.mark.asyncio
+    async def test_exits_on_missing_uuid(self):
+        req = DummyLegacyRequest(
+            pickup_servicepoint_id="00000000-0000-0000-0000-000000000099"
+        )
+        folio_sps = [{"id": "sp-uuid-1", "code": "circ-desk"}]
+        m = self._make_migrator([req], folio_sps)
+
+        with pytest.raises(SystemExit):
+            await RequestsMigrator.pre_validate_service_points(m)
+
+    @pytest.mark.asyncio
+    async def test_exits_on_missing_code(self):
+        req = DummyLegacyRequest(pickup_servicepoint_id="bad-code")
+        folio_sps = [{"id": "sp-uuid-1", "code": "circ-desk"}]
+        m = self._make_migrator([req], folio_sps)
+
+        with pytest.raises(SystemExit):
+            await RequestsMigrator.pre_validate_service_points(m)
+
+    @pytest.mark.asyncio
+    async def test_no_requests_returns_early(self):
+        m = Mock(spec=RequestsMigrator)
+        m.semi_valid_legacy_requests = []
+        m.folio_client = Mock()
+        sp_mock = PropertyMock()
+        type(m.folio_client).service_points = sp_mock
+
+        await RequestsMigrator.pre_validate_service_points(m)
+
+        sp_mock.assert_not_called()
+
+
+class TestServicePointMappingInit:
+    """Test _init_service_point_mapping using real RefDataMapping and mocked FolioClient."""
+
+    def test_creates_ref_data_mapping_from_tsv_file(self, tmp_path):
+        """Integration: loads a real TSV mapping file and produces a RefDataMapping."""
+        import csv
+
+        csv.register_dialect("tsv", delimiter="\t")
+        # Create a TSV mapping file with legacy_code -> folio_code
+        map_file = tmp_path / "sp_map.tsv"
+        map_file.write_text("service_point_id\tfolio_code\nold_desk\tlmd\n*\tfo\n")
+
+        m = Mock(spec=RequestsMigrator)
+        m.folio_client = mocked_classes.mocked_folio_client()
+        m.folder_structure = Mock()
+        m.folder_structure.mapping_files_folder = tmp_path
+        m.load_ref_data_mapping_file = RequestsMigrator.load_ref_data_mapping_file
+
+        task_config = Mock()
+        task_config.service_point_map_file_name = "sp_map.tsv"
+
+        RequestsMigrator._init_service_point_mapping(m, task_config)
+
+        assert isinstance(m.service_point_mapping, RefDataMapping)
+        assert m.service_point_mapping.default_id == "finance_office_uuid"
+        assert m.service_point_mapping.regular_mappings[0]["folio_id"] == "library_main_desk_uuid"
+
+    def test_skips_loading_when_no_map_file_configured(self):
+        m = Mock(spec=RequestsMigrator)
+        m.load_ref_data_mapping_file = RequestsMigrator.load_ref_data_mapping_file
+
+        task_config = Mock()
+        task_config.service_point_map_file_name = ""
+
+        RequestsMigrator._init_service_point_mapping(m, task_config)
+
+        assert m.service_point_mapping is None
+
+    def test_sets_none_when_map_file_does_not_exist(self, tmp_path):
+        """When the configured file doesn't exist, service_point_mapping stays None."""
+        m = Mock(spec=RequestsMigrator)
+        m.folio_client = mocked_classes.mocked_folio_client()
+        m.folder_structure = Mock()
+        m.folder_structure.mapping_files_folder = tmp_path
+        m.load_ref_data_mapping_file = RequestsMigrator.load_ref_data_mapping_file
+
+        task_config = Mock()
+        task_config.service_point_map_file_name = "nonexistent.tsv"
+
+        RequestsMigrator._init_service_point_mapping(m, task_config)
+
+        assert m.service_point_mapping is None

--- a/tests/test_requests_migrator.py
+++ b/tests/test_requests_migrator.py
@@ -6,6 +6,7 @@ from folio_uuid.folio_namespaces import FOLIONamespaces
 from folio_migration_tools.mapping_file_transformation.ref_data_mapping import (
     RefDataMapping,
 )
+from folio_migration_tools.migration_tasks.migration_task_base import MigrationTaskBase
 from folio_migration_tools.migration_tasks.requests_migrator import RequestsMigrator
 from .test_infrastructure import mocked_classes
 
@@ -211,28 +212,29 @@ class TestPreValidateServicePoints:
         m.folio_client.service_points = folio_service_points or []
         return m
 
-    @pytest.mark.asyncio
-    async def test_resolves_code_to_uuid(self):
+    def test_resolves_code_to_uuid(self):
         req = DummyLegacyRequest(pickup_servicepoint_id="circ-desk")
         folio_sps = [{"id": "sp-uuid-1", "code": "circ-desk"}]
         m = self._make_migrator([req], folio_sps)
 
-        await RequestsMigrator.pre_validate_service_points(m)
+        MigrationTaskBase._pre_validate_service_points(
+            m, [req], "pickup_servicepoint_id"
+        )
 
         assert req.pickup_servicepoint_id == "sp-uuid-1"
 
-    @pytest.mark.asyncio
-    async def test_uuid_passes_through_unchanged(self):
+    def test_uuid_passes_through_unchanged(self):
         req = DummyLegacyRequest(pickup_servicepoint_id="sp-uuid-1")
         folio_sps = [{"id": "sp-uuid-1", "code": "circ-desk"}]
         m = self._make_migrator([req], folio_sps)
 
-        await RequestsMigrator.pre_validate_service_points(m)
+        MigrationTaskBase._pre_validate_service_points(
+            m, [req], "pickup_servicepoint_id"
+        )
 
         assert req.pickup_servicepoint_id == "sp-uuid-1"
 
-    @pytest.mark.asyncio
-    async def test_exits_on_missing_uuid(self):
+    def test_exits_on_missing_uuid(self):
         req = DummyLegacyRequest(
             pickup_servicepoint_id="00000000-0000-0000-0000-000000000099"
         )
@@ -240,26 +242,29 @@ class TestPreValidateServicePoints:
         m = self._make_migrator([req], folio_sps)
 
         with pytest.raises(SystemExit):
-            await RequestsMigrator.pre_validate_service_points(m)
+            MigrationTaskBase._pre_validate_service_points(
+                m, [req], "pickup_servicepoint_id"
+            )
 
-    @pytest.mark.asyncio
-    async def test_exits_on_missing_code(self):
+    def test_exits_on_missing_code(self):
         req = DummyLegacyRequest(pickup_servicepoint_id="bad-code")
         folio_sps = [{"id": "sp-uuid-1", "code": "circ-desk"}]
         m = self._make_migrator([req], folio_sps)
 
         with pytest.raises(SystemExit):
-            await RequestsMigrator.pre_validate_service_points(m)
+            MigrationTaskBase._pre_validate_service_points(
+                m, [req], "pickup_servicepoint_id"
+            )
 
-    @pytest.mark.asyncio
-    async def test_no_requests_returns_early(self):
+    def test_no_requests_returns_early(self):
         m = Mock(spec=RequestsMigrator)
-        m.semi_valid_legacy_requests = []
         m.folio_client = Mock()
         sp_mock = PropertyMock()
         type(m.folio_client).service_points = sp_mock
 
-        await RequestsMigrator.pre_validate_service_points(m)
+        MigrationTaskBase._pre_validate_service_points(
+            m, [], "pickup_servicepoint_id"
+        )
 
         sp_mock.assert_not_called()
 


### PR DESCRIPTION
## Purpose

Fixes #1034
Fixes #1036

Both the loans and requests migrators previously required service point values to be UUIDs. This forced users to look up UUIDs manually before preparing source data. This PR allows service point references (in both the fallback config parameter and the source data columns) to be either UUIDs or FOLIO service point codes. It also adds an optional TSV mapping file to translate legacy codes to FOLIO codes.

## Changes Made in this PR

- **`utils.py`**: Added shared `is_uuid()` helper for UUID detection
- **legacy_loan.py / legacy_request.py**: New `_get_service_point_value()` method that resolves service points through fallback → UUID pass-through → mapping lookup → code-as-is flow
- **loans_migrator.py / requests_migrator.py**:
  - New `servicePointMapFileName` config parameter for optional TSV mapping
  - Extracted `_init_service_point_mapping()` to load and initialize the `RefDataMapping`
  - `_validate_fallback_service_point()` validates the fallback against FOLIO (accepts UUID or code)
  - `pre_validate_service_points()` validates all source service point values before barcode validation, halting on any invalid value, then resolves codes to UUIDs
- **UserImportTask**: Added support for new task config parameter to control PermissionsUser handling
- **Docs**: Updated loans_migrator.md and requests_migrator.md with new parameters, mapping file format, and examples
- **Tests**: Integration tests using `mocked_folio_client` with real `RefDataMapping` and `load_ref_data_mapping_file`; unit tests for pre-validation, code→UUID resolution, and early-exit paths

## Code Review Specifics

- Read the code, make suggestions
- Pay attention to the `_get_service_point_value` flow in legacy_loan.py / legacy_request.py — these are the core resolution methods
- The `RefDataMapping` requires a `*` wildcard row in the TSV but it's not used as a runtime fallback (documented)

## Task Checklist

- [ ] Ran `nox -rs safety`.
- [ ] Ran `pre-commit run --all-files`
- [x] Tests cover new or modified code.
- [x] Ran test suite: `nox -rs tests`
- [ ] Code runs and outputs default usage info: `cd src; poetry run python3 -m folio_migration_tools -h`
- [x] Documentation updated

## Warning Checklist

- [ ] New dependencies added
- [ ] Includes breaking changes

## How to Verify

1. Configure a loans or requests task with `"fallbackServicePointId": "circ-desk"` (a code) instead of a UUID
2. Add `"servicePointMapFileName": "sp_map.tsv"` pointing to a TSV with `service_point_id\tfolio_code` columns
3. Run the task — service points are validated up front and codes are resolved to UUIDs before any circulation API calls
4. Verify that invalid codes/UUIDs cause the task to halt immediately with a clear error message

## Learn Anything Cool?
